### PR TITLE
feat: remove dd trace type

### DIFF
--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -1,4 +1,9 @@
-import type { Configuration, InitConfiguration, MatchOption, RawTelemetryConfiguration } from '@flashcatcloud/browser-core'
+import type {
+  Configuration,
+  InitConfiguration,
+  MatchOption,
+  RawTelemetryConfiguration,
+} from '@flashcatcloud/browser-core'
 import {
   getType,
   isMatchOption,
@@ -17,7 +22,7 @@ import type { RumPlugin } from '../plugins'
 import { isTracingOption } from '../tracing/tracer'
 import type { PropagatorType, TracingOption } from '../tracing/tracer.types'
 
-export const DEFAULT_PROPAGATOR_TYPES: PropagatorType[] = ['tracecontext', 'datadog']
+export const DEFAULT_PROPAGATOR_TYPES: PropagatorType[] = ['tracecontext']
 
 export interface RumInitConfiguration extends InitConfiguration {
   // global options

--- a/packages/rum-core/src/domain/tracing/tracer.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.ts
@@ -177,15 +177,6 @@ function makeTracingHeaders(
 
   propagatorTypes.forEach((propagatorType) => {
     switch (propagatorType) {
-      case 'datadog': {
-        Object.assign(tracingHeaders, {
-          'x-datadog-origin': 'rum',
-          'x-datadog-parent-id': spanId.toString(),
-          'x-datadog-sampling-priority': traceSampled ? '1' : '0',
-          'x-datadog-trace-id': traceId.toString(),
-        })
-        break
-      }
       // https://www.w3.org/TR/trace-context/
       case 'tracecontext': {
         Object.assign(tracingHeaders, {

--- a/packages/rum-core/src/domain/tracing/tracer.types.ts
+++ b/packages/rum-core/src/domain/tracing/tracer.types.ts
@@ -6,5 +6,5 @@ import type { MatchOption } from '@flashcatcloud/browser-core'
  * b3: B3 Single Header (b3)
  * b3multi: B3 Multiple Headers (X-B3-*)
  */
-export type PropagatorType = 'datadog' | 'b3' | 'b3multi' | 'tracecontext'
+export type PropagatorType = 'b3' | 'b3multi' | 'tracecontext'
 export type TracingOption = { match: MatchOption; propagatorTypes: PropagatorType[] }


### PR DESCRIPTION
## Motivation
we do not support datadog trace and span.

## Changes
1. remove datadog trace
2. remove datadog type from default propagatorTypes. 

## Testing

<!-- How can the reviewer confirm these changes do what you say they do? Are there automated tests? -->

- [ ] Local

---

I have gone over the [contributing](https://github.com/DataDog/browser-sdk/blob/main/CONTRIBUTING.md) documentation.
