### PR TITLE
feat(rum): add trackWebVitals config to opt out of initial view metrics

### DIFF
--- a/packages/rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.spec.ts
@@ -369,6 +369,28 @@ describe('validateAndBuildRumConfiguration', () => {
     })
   })
 
+  describe('trackWebVitals', () => {
+    it('defaults to true', () => {
+      expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.trackWebVitals).toBeTrue()
+    })
+
+    it('is set to provided value', () => {
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackWebVitals: true })!.trackWebVitals
+      ).toBeTrue()
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackWebVitals: false })!.trackWebVitals
+      ).toBeFalse()
+    })
+
+    it('the provided value is cast to boolean', () => {
+      expect(
+        validateAndBuildRumConfiguration({ ...DEFAULT_INIT_CONFIGURATION, trackWebVitals: 'foo' as any })!
+          .trackWebVitals
+      ).toBeTrue()
+    })
+  })
+
   describe('trackResources', () => {
     it('defaults to true', () => {
       expect(validateAndBuildRumConfiguration(DEFAULT_INIT_CONFIGURATION)!.trackResources).toBeTrue()
@@ -535,6 +557,7 @@ describe('serializeRumConfiguration', () => {
       trackUserInteractions: true,
       actionNameAttribute: 'test-id',
       trackViewsManually: true,
+      trackWebVitals: true,
       trackResources: true,
       trackLongTasks: true,
       remoteConfigurationId: '123',
@@ -556,6 +579,7 @@ describe('serializeRumConfiguration', () => {
                 | 'remoteConfigurationId'
                 | 'profilingSampleRate'
                 | 'propagateTraceBaggage'
+                | 'trackWebVitals'
             ? never
             : CamelToSnakeCase<Key>
     // By specifying the type here, we can ensure that serializeConfiguration is returning an

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -128,6 +128,14 @@ export interface RumInitConfiguration extends InitConfiguration {
    */
   trackViewsManually?: boolean | undefined
   /**
+   * Enables collection of Web Vitals / initial view metrics (FCP, LCP, FID, loading time) on the
+   * initial load view. Disable it for pages that are loaded in the background or pre-warmed (e.g. a
+   * hidden Electron window) where these metrics would be measured from an irrelevant navigation
+   * start and reported as abnormally large values.
+   * @default true
+   */
+  trackWebVitals?: boolean | undefined
+  /**
    * Enables collection of resource events.
    * @default true
    */
@@ -178,6 +186,7 @@ export interface RumConfiguration extends Configuration {
   startSessionReplayRecordingManually: boolean
   trackUserInteractions: boolean
   trackViewsManually: boolean
+  trackWebVitals: boolean
   trackResources: boolean
   trackLongTasks: boolean
   version?: string
@@ -248,6 +257,7 @@ export function validateAndBuildRumConfiguration(
     compressIntakeRequests: !!initConfiguration.compressIntakeRequests,
     trackUserInteractions: !!(initConfiguration.trackUserInteractions ?? true),
     trackViewsManually: !!initConfiguration.trackViewsManually,
+    trackWebVitals: !!(initConfiguration.trackWebVitals ?? true),
     trackResources: !!(initConfiguration.trackResources ?? true),
     trackLongTasks: !!(initConfiguration.trackLongTasks ?? true),
     subdomain: initConfiguration.subdomain,

--- a/packages/rum-core/src/domain/view/trackViews.spec.ts
+++ b/packages/rum-core/src/domain/view/trackViews.spec.ts
@@ -447,6 +447,21 @@ describe('view metrics', () => {
   })
 
   describe('initial view metrics', () => {
+    it('should not be collected when trackWebVitals is disabled', () => {
+      viewTest.stop()
+      viewTest = setupViewTest({ lifeCycle, partialConfig: { trackWebVitals: false } })
+
+      notifyPerformanceEntries([
+        createPerformanceEntry(RumPerformanceEntryType.PAINT),
+        createPerformanceEntry(RumPerformanceEntryType.NAVIGATION),
+        createPerformanceEntry(RumPerformanceEntryType.LARGEST_CONTENTFUL_PAINT),
+      ])
+      clock.tick(THROTTLE_VIEW_UPDATE_PERIOD)
+
+      const { getViewUpdate, getViewUpdateCount } = viewTest
+      expect(getViewUpdate(getViewUpdateCount() - 1).initialViewMetrics).toEqual({})
+    })
+
     it('updates should be throttled', () => {
       const { getViewUpdateCount, getViewUpdate } = viewTest
       expect(getViewUpdateCount()).toEqual(1)

--- a/packages/rum-core/src/domain/view/trackViews.ts
+++ b/packages/rum-core/src/domain/view/trackViews.ts
@@ -252,7 +252,7 @@ function newView(
   )
 
   const { stop: stopInitialViewMetricsTracking, initialViewMetrics } =
-    loadingType === ViewLoadingType.INITIAL_LOAD
+    loadingType === ViewLoadingType.INITIAL_LOAD && configuration.trackWebVitals
       ? trackInitialViewMetrics(configuration, setLoadEvent, scheduleViewUpdate)
       : { stop: noop, initialViewMetrics: {} as InitialViewMetrics }
 


### PR DESCRIPTION
## Background

A customer integrates the browser SDK into a pre-warmed, hidden Electron `BrowserWindow`: the window is created with `show: false`, RUM is initialized immediately, and the actual image content is rendered much later (via IPC) when a preview is needed. RUM then reports an **abnormally large LCP**.

## Root cause

Initial view metrics (FCP / LCP / FID / loading time) are:
- anchored to the page navigation start (`clocksOrigin()` in `trackViews.ts`), **not** to when `init()` / `startView()` is called, and
- only collected on the `INITIAL_LOAD` view.

So when content paints long after navigation, LCP = `paint - navigationStart`, i.e. huge. The existing safeguards don't catch it:
- `trackFirstHidden` discards LCP after the page first becomes hidden — but a hidden Electron window does **not** reliably report `document.visibilityState === 'hidden'`, so the safeguard never triggers.
- the 10-minute `LCP_MAXIMUM_DELAY` cap only filters truly extreme values.

Deferring `init()` / using `trackViewsManually` + manual `startView()` does **not** fix it either, because none of those re-baseline `timeOrigin` — only a real navigation does.

## Change

Add a `trackWebVitals` init option (default `true`). When `false`, `trackInitialViewMetrics` is not started for that SDK instance, so FCP/LCP/FID/loading-time are simply **absent** for that page rather than reported as a misleading value. This fits the "separate window has its own `init`" case cleanly — the preview window opts out, the main app is unaffected.

```ts
flashcatRum.init({
  applicationId: '...',
  clientToken: '...',
  trackWebVitals: false, // skip FCP/LCP/FID/loading-time on this (pre-warmed/hidden) page
})
```

## Notes

- Like `profilingSampleRate` and `propagateTraceBaggage`, this fork-specific option is **not** part of the upstream telemetry schema, so it is intentionally excluded from `serializeRumConfiguration` (`telemetryEvent.types.ts` is generated — "DO NOT MODIFY BY HAND"). The exhaustive `serializeRumConfiguration` test is updated accordingly.
- Scope is limited to opting out of collection. It does **not** open the LCP value field in `beforeSend` (the metric value is deliberately not in the modifiable whitelist).

## Tests

- `configuration.spec.ts`: `trackWebVitals` defaults to `true`, honors provided value, casts to boolean.
- `trackViews.spec.ts`: initial view metrics are not collected when `trackWebVitals: false`.
- Full unit suite green (2656 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)