### PR TITLE
feat(rum): keep collecting Session Replay in the page when a host bridge is present

### DIFF
--- a/packages/core/src/transport/eventBridge.ts
+++ b/packages/core/src/transport/eventBridge.ts
@@ -10,6 +10,17 @@ export interface DatadogEventBridge {
   getPrivacyLevel?(): DefaultPrivacyLevel
   getAllowedWebViewHosts(): string
   send(msg: string): void
+  /**
+   * FLASHCAT FORK: identifiers owned by the host application.
+   *
+   * Both are optional: hosts built against an older SDK do not implement them, in which case the
+   * web SDK falls back to its own placeholder values.
+   *
+   * They are expected to be synchronous: the host pushes updates to the bridge implementation
+   * (e.g. an Electron preload script), which caches them and answers from that cache.
+   */
+  getSessionId?(): string
+  getAnonymousId?(): string
 }
 
 export const enum BridgeCapability {
@@ -32,6 +43,13 @@ export function getEventBridge<T, E>() {
     },
     getAllowedWebViewHosts() {
       return JSON.parse(eventBridgeGlobal.getAllowedWebViewHosts()) as string[]
+    },
+    // FLASHCAT FORK: see `DatadogEventBridge`. Returns `undefined` when the host does not provide it.
+    getSessionId() {
+      return eventBridgeGlobal.getSessionId?.() || undefined
+    },
+    getAnonymousId() {
+      return eventBridgeGlobal.getAnonymousId?.() || undefined
     },
     send(eventType: T, event: E, viewId?: string) {
       const view = viewId ? { id: viewId } : undefined

--- a/packages/core/test/emulate/mockEventBridge.ts
+++ b/packages/core/test/emulate/mockEventBridge.ts
@@ -7,12 +7,24 @@ export function mockEventBridge({
   allowedWebViewHosts = [window.location.hostname],
   privacyLevel = DefaultPrivacyLevel.MASK,
   capabilities = [BridgeCapability.RECORDS],
-}: { allowedWebViewHosts?: string[]; privacyLevel?: DefaultPrivacyLevel; capabilities?: BridgeCapability[] } = {}) {
+  sessionId,
+  anonymousId,
+}: {
+  allowedWebViewHosts?: string[]
+  privacyLevel?: DefaultPrivacyLevel
+  capabilities?: BridgeCapability[]
+  // FLASHCAT FORK: host provided identifiers. When left out, the bridge does not implement the
+  // corresponding method at all, which emulates a host built against an older SDK.
+  sessionId?: string
+  anonymousId?: string
+} = {}) {
   const eventBridge: DatadogEventBridge = {
     send: (_msg: string) => undefined,
     getAllowedWebViewHosts: () => JSON.stringify(allowedWebViewHosts),
     getCapabilities: () => JSON.stringify(capabilities),
     getPrivacyLevel: () => privacyLevel,
+    ...(sessionId !== undefined ? { getSessionId: () => sessionId } : {}),
+    ...(anonymousId !== undefined ? { getAnonymousId: () => anonymousId } : {}),
   }
 
   ;(window as BrowserWindowWithEventBridge).DatadogEventBridge = eventBridge

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -108,7 +108,7 @@ export function startRum(
 
   const session = !canUseEventBridge()
     ? startRumSessionManager(configuration, lifeCycle, trackingConsentState)
-    : startRumSessionManagerStub()
+    : startRumSessionManagerStub(configuration)
 
   if (!canUseEventBridge()) {
     const batch = startRumBatch(

--- a/packages/rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.spec.ts
@@ -530,6 +530,7 @@ describe('serializeRumConfiguration', () => {
       subdomain: 'foo',
       sessionReplaySampleRate: 60,
       startSessionReplayRecordingManually: true,
+      sessionReplayDirectUpload: true,
       trackUserInteractions: true,
       actionNameAttribute: 'test-id',
       trackViewsManually: true,
@@ -554,6 +555,8 @@ describe('serializeRumConfiguration', () => {
                 | 'remoteConfigurationId'
                 | 'profilingSampleRate'
                 | 'propagateTraceBaggage'
+                // FLASHCAT FORK: not reported to telemetry
+                | 'sessionReplayDirectUpload'
             ? never
             : CamelToSnakeCase<Key>
     // By specifying the type here, we can ensure that serializeConfiguration is returning an

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -105,6 +105,24 @@ export interface RumInitConfiguration extends InitConfiguration {
    * See [Session Replay Usage](https://docs.datadoghq.com/real_user_monitoring/session_replay/browser/#usage) for further information.
    */
   startSessionReplayRecordingManually?: boolean | undefined
+  /**
+   * When the SDK runs inside a host application that injects an event bridge (an Electron renderer
+   * process, a mobile WebView...), Session Replay is normally handed over to the host application,
+   * and is not collected at all when the host does not implement it.
+   *
+   * Set this to `true` to keep collecting Session Replay in the page and upload it from here, over
+   * the same intake connection a regular web page uses. Use it when the host application does not
+   * record Session Replay itself.
+   *
+   * This has no effect outside of a host application (no event bridge), where Session Replay is
+   * always collected and uploaded by this SDK.
+   *
+   * Note: `sessionReplaySampleRate` defaults to 0, so it must be set explicitly as well, otherwise
+   * nothing is recorded.
+   *
+   * @default false
+   */
+  sessionReplayDirectUpload?: boolean | undefined
 
   /**
    * Enables privacy control for action names.
@@ -176,6 +194,7 @@ export interface RumConfiguration extends Configuration {
   enablePrivacyForActionName: boolean
   sessionReplaySampleRate: number
   startSessionReplayRecordingManually: boolean
+  sessionReplayDirectUpload: boolean
   trackUserInteractions: boolean
   trackViewsManually: boolean
   trackResources: boolean
@@ -240,6 +259,7 @@ export function validateAndBuildRumConfiguration(
       initConfiguration.startSessionReplayRecordingManually !== undefined
         ? !!initConfiguration.startSessionReplayRecordingManually
         : sessionReplaySampleRate === 0,
+    sessionReplayDirectUpload: !!initConfiguration.sessionReplayDirectUpload,
     traceSampleRate: initConfiguration.traceSampleRate ?? 100,
     rulePsr: isNumber(initConfiguration.traceSampleRate) ? initConfiguration.traceSampleRate / 100 : undefined,
     allowedTracingUrls,

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -27,6 +27,7 @@ import {
   RUM_SESSION_KEY,
   RumTrackingType,
   SessionReplayState,
+  STUB_SESSION_ID,
   startRumSessionManager,
   startRumSessionManagerStub,
 } from './rumSessionManager'
@@ -227,11 +228,70 @@ describe('rum session manager', () => {
 describe('rum session manager stub', () => {
   it('should return a tracked session with replay allowed when the event bridge support records', () => {
     mockEventBridge({ capabilities: [BridgeCapability.RECORDS] })
-    expect(startRumSessionManagerStub().findTrackedSession()!.sessionReplay).toEqual(SessionReplayState.SAMPLED)
+    expect(startRumSessionManagerStub(mockRumConfiguration()).findTrackedSession()!.sessionReplay).toEqual(
+      SessionReplayState.SAMPLED
+    )
   })
 
   it('should return a tracked session without replay allowed when the event bridge support records', () => {
     mockEventBridge({ capabilities: [] })
-    expect(startRumSessionManagerStub().findTrackedSession()!.sessionReplay).toEqual(SessionReplayState.OFF)
+    expect(startRumSessionManagerStub(mockRumConfiguration()).findTrackedSession()!.sessionReplay).toEqual(
+      SessionReplayState.OFF
+    )
+  })
+
+  // FLASHCAT FORK - see `sessionReplayDirectUpload` in RumInitConfiguration.
+  describe('with sessionReplayDirectUpload', () => {
+    it('should return a tracked session with replay allowed even when the bridge does not support records', () => {
+      mockEventBridge({ capabilities: [] })
+      const configuration = mockRumConfiguration({ sessionReplayDirectUpload: true, sessionReplaySampleRate: 100 })
+      expect(startRumSessionManagerStub(configuration).findTrackedSession()!.sessionReplay).toEqual(
+        SessionReplayState.SAMPLED
+      )
+    })
+
+    it('should honor sessionReplaySampleRate', () => {
+      mockEventBridge({ capabilities: [] })
+      const configuration = mockRumConfiguration({ sessionReplayDirectUpload: true, sessionReplaySampleRate: 0 })
+      expect(startRumSessionManagerStub(configuration).findTrackedSession()!.sessionReplay).toEqual(
+        SessionReplayState.OFF
+      )
+    })
+  })
+
+  // FLASHCAT FORK - the host application owns the session id and the anonymous id.
+  describe('host provided identifiers', () => {
+    it('should use the session id and the anonymous id provided by the bridge', () => {
+      mockEventBridge({ sessionId: 'host-session-id', anonymousId: 'host-anonymous-id' })
+      const session = startRumSessionManagerStub(mockRumConfiguration()).findTrackedSession()!
+      expect(session.id).toBe('host-session-id')
+      expect(session.anonymousId).toBe('host-anonymous-id')
+    })
+
+    it('should fall back to the placeholder session id when the bridge does not implement the methods', () => {
+      mockEventBridge()
+      const session = startRumSessionManagerStub(mockRumConfiguration()).findTrackedSession()!
+      expect(session.id).toBe(STUB_SESSION_ID)
+      expect(session.anonymousId).toBeUndefined()
+    })
+
+    it('should fall back to the placeholder session id when the bridge returns an empty session id', () => {
+      mockEventBridge({ sessionId: '', anonymousId: '' })
+      const session = startRumSessionManagerStub(mockRumConfiguration()).findTrackedSession()!
+      expect(session.id).toBe(STUB_SESSION_ID)
+      expect(session.anonymousId).toBeUndefined()
+    })
+
+    it('should read the session id again on each call, as the host renews it', () => {
+      let sessionId = 'first-session-id'
+      const eventBridge = mockEventBridge({ sessionId: '' })
+      eventBridge.getSessionId = () => sessionId
+
+      const sessionManager = startRumSessionManagerStub(mockRumConfiguration())
+      expect(sessionManager.findTrackedSession()!.id).toBe('first-session-id')
+
+      sessionId = 'renewed-session-id'
+      expect(sessionManager.findTrackedSession()!.id).toBe('renewed-session-id')
+    })
   })
 })

--- a/packages/rum-core/src/domain/rumSessionManager.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.ts
@@ -3,6 +3,7 @@ import {
   BridgeCapability,
   Observable,
   bridgeSupports,
+  getEventBridge,
   noop,
   performDraw,
   startSessionManager,
@@ -96,15 +97,35 @@ export function startRumSessionManager(
 }
 
 /**
+ * Session id used when the host application does not provide one. The host application is expected
+ * to override the session id of the events it forwards, so the placeholder never reaches the intake
+ * for RUM events. It does reach the intake for Session Replay segments, which are uploaded by this
+ * page directly, hence the `getSessionId()` lookup below.
+ */
+export const STUB_SESSION_ID = '00000000-aaaa-0000-aaaa-000000000000'
+
+/**
  * Start a tracked replay session stub
  */
-export function startRumSessionManagerStub(): RumSessionManager {
-  const session: RumSession = {
-    id: '00000000-aaaa-0000-aaaa-000000000000',
-    sessionReplay: bridgeSupports(BridgeCapability.RECORDS) ? SessionReplayState.SAMPLED : SessionReplayState.OFF,
-  }
+export function startRumSessionManagerStub(configuration: RumConfiguration): RumSessionManager {
+  // FLASHCAT FORK (3/3) - see `sessionReplayDirectUpload` in RumInitConfiguration.
+  // Session Replay segments uploaded from this page are joined to a session by `(account, session
+  // id)`, so they need the session id the host application actually uses, not the placeholder.
+  // `getSessionId()`/`getAnonymousId()` are absent on older host SDKs, hence the fallbacks.
+  const bridge = getEventBridge()
+  const sessionReplay =
+    bridgeSupports(BridgeCapability.RECORDS) ||
+    (configuration.sessionReplayDirectUpload && performDraw(configuration.sessionReplaySampleRate))
+      ? SessionReplayState.SAMPLED
+      : SessionReplayState.OFF
+
   return {
-    findTrackedSession: () => session,
+    // Read from the bridge on each call: the host application renews its session id over time.
+    findTrackedSession: (): RumSession => ({
+      id: bridge?.getSessionId() ?? STUB_SESSION_ID,
+      sessionReplay,
+      anonymousId: bridge?.getAnonymousId(),
+    }),
     expire: noop,
     expireObservable: new Observable(),
     setForcedReplay: noop,

--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -30,7 +30,12 @@ describe('makeRecorderApi', () => {
   function setupRecorderApi({
     sessionManager,
     startSessionReplayRecordingManually,
-  }: { sessionManager?: RumSessionManager; startSessionReplayRecordingManually?: boolean } = {}) {
+    sessionReplayDirectUpload,
+  }: {
+    sessionManager?: RumSessionManager
+    startSessionReplayRecordingManually?: boolean
+    sessionReplayDirectUpload?: boolean
+  } = {}) {
     mockWorker = new MockWorker()
     createDeflateWorkerSpy = jasmine.createSpy('createDeflateWorkerSpy').and.callFake(() => mockWorker)
     spyOn(display, 'error')
@@ -51,7 +56,10 @@ describe('makeRecorderApi', () => {
     rumInit = ({ worker } = {}) => {
       recorderApi.onRumStart(
         lifeCycle,
-        mockRumConfiguration({ startSessionReplayRecordingManually: startSessionReplayRecordingManually ?? false }),
+        mockRumConfiguration({
+          startSessionReplayRecordingManually: startSessionReplayRecordingManually ?? false,
+          sessionReplayDirectUpload: sessionReplayDirectUpload ?? false,
+        }),
         sessionManager ?? createRumSessionManagerMock().setId('1234'),
         mockViewHistory(),
         worker
@@ -258,6 +266,18 @@ describe('makeRecorderApi', () => {
 
         expect(loadRecorderSpy).not.toHaveBeenCalled()
         expect(startRecordingSpy).not.toHaveBeenCalled()
+      })
+
+      // FLASHCAT FORK - see `sessionReplayDirectUpload` in RumInitConfiguration.
+      it('should start recording when the bridge does not support records but sessionReplayDirectUpload is set', async () => {
+        mockEventBridge({ capabilities: [] })
+
+        setupRecorderApi({ startSessionReplayRecordingManually: true, sessionReplayDirectUpload: true })
+        rumInit()
+        recorderApi.start()
+        await collectAsyncCalls(startRecordingSpy, 1)
+
+        expect(startRecordingSpy).toHaveBeenCalled()
       })
     })
 

--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -31,7 +31,11 @@ export function makeRecorderApi(
   loadRecorder: () => Promise<StartRecording | undefined>,
   createDeflateWorkerImpl?: CreateDeflateWorker
 ): RecorderApi {
-  if ((canUseEventBridge() && !bridgeSupports(BridgeCapability.RECORDS)) || !isBrowserSupported()) {
+  // FLASHCAT FORK (1/3) - see `sessionReplayDirectUpload` in RumInitConfiguration.
+  // Upstream also disables the recorder here when an event bridge is present without the `records`
+  // capability. That check now lives in `onRumStart` below, because it depends on a configuration
+  // option that is not known yet when this function runs.
+  if (!isBrowserSupported()) {
     return {
       start: noop,
       stop: noop,
@@ -86,6 +90,14 @@ export function makeRecorderApi(
     viewHistory: ViewHistory,
     worker: DeflateWorker | undefined
   ) {
+    // FLASHCAT FORK (1/3) - see `sessionReplayDirectUpload` in RumInitConfiguration.
+    // A host application declaring the `records` capability collects the records itself. When it
+    // does not, upstream gives up on Session Replay entirely; `sessionReplayDirectUpload` opts out
+    // of that and keeps the regular in-page recorder running.
+    if (canUseEventBridge() && !bridgeSupports(BridgeCapability.RECORDS) && !configuration.sessionReplayDirectUpload) {
+      return
+    }
+
     let cachedDeflateEncoder: DeflateEncoder | undefined
 
     function getOrCreateDeflateEncoder() {

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -1,6 +1,6 @@
 import type { TimeStamp, HttpRequest } from '@flashcatcloud/browser-core'
 import { PageExitReason, DefaultPrivacyLevel, noop, DeflateEncoderStreamId } from '@flashcatcloud/browser-core'
-import type { ViewCreatedEvent } from '@flashcatcloud/browser-rum-core'
+import type { RumConfiguration, ViewCreatedEvent } from '@flashcatcloud/browser-rum-core'
 import { LifeCycle, LifeCycleEventType, startViewHistory } from '@flashcatcloud/browser-rum-core'
 import { collectAsyncCalls, createNewEvent, mockEventBridge, registerCleanupTask } from '@flashcatcloud/browser-core/test'
 import type { ViewEndedEvent } from 'packages/rum-core/src/domain/view/trackViews'
@@ -25,8 +25,11 @@ describe('startRecording', () => {
   let requestSendSpy: jasmine.Spy<HttpRequest['sendOnExit']>
   let stopRecording: () => void
 
-  function setupStartRecording() {
-    const configuration = mockRumConfiguration({ defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW })
+  function setupStartRecording(partialConfiguration: Partial<RumConfiguration> = {}) {
+    const configuration = mockRumConfiguration({
+      defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
+      ...partialConfiguration,
+    })
     resetReplayStats()
     const worker = startDeflateWorker(configuration, 'Session Replay', noop)
 
@@ -230,6 +233,19 @@ describe('startRecording', () => {
       event: jasmine.objectContaining({ type: RecordType.Meta }),
       view: { id: 'view-id-2' },
     })
+  })
+
+  // FLASHCAT FORK - see `sessionReplayDirectUpload` in RumInitConfiguration.
+  it('should send segments itself when the bridge is present but sessionReplayDirectUpload is set', async () => {
+    const eventBridge = mockEventBridge()
+    const sendSpy = spyOn(eventBridge, 'send')
+    setupStartRecording({ sessionReplayDirectUpload: true })
+
+    flushSegment(lifeCycle)
+
+    const requests = await readSentRequests(1)
+    expect(requests[0].metadata.session).toEqual({ id: 'session-id' })
+    expect(sendSpy).not.toHaveBeenCalled()
   })
 
   function initialView(lifeCycle: LifeCycle) {

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -28,7 +28,10 @@ export function startRecording(
 
   let addRecord: (record: BrowserRecord) => void
 
-  if (!canUseEventBridge()) {
+  // FLASHCAT FORK (2/3) - see `sessionReplayDirectUpload` in RumInitConfiguration.
+  // Without the option, records are handed over to the host application through the bridge. With
+  // it, they go through the regular segment collection and are uploaded from this page.
+  if (!canUseEventBridge() || configuration.sessionReplayDirectUpload) {
     const segmentCollection = startSegmentCollection(
       lifeCycle,
       configuration,


### PR DESCRIPTION
## What

Adds a `sessionReplayDirectUpload` init option to `@flashcatcloud/browser-rum`, so that a page embedded in a host application keeps collecting Session Replay and uploads it itself, instead of handing it over to the host.

Draft: **do not merge, do not publish.**

## Why

When the SDK runs inside a host application that injects a `DatadogEventBridge` (an Electron renderer process, a mobile WebView), upstream assumes the host takes over Session Replay. If the host does not declare the `records` capability, the whole recorder API is replaced by a no-op shell and no replay is collected at all.

Our Electron SDK (`@flashcatcloud/electron-sdk`) injects the bridge from its preload script but returns an empty capability list, so customers who had working Session Replay lose it as soon as they adopt the Electron SDK.

The upstream design — the host receives raw records over `bridge.send('record', ...)` and does the segmentation, compression and multipart upload itself — is a large amount of work and has no Electron implementation upstream to this day. This change takes the other route: let the page stay on the path it already uses on the web.

The intake side needs no change. The payload, the endpoint builder (including `proxy`, which applies to the `replay` track exactly like to `rum`) and the authentication (`dd-api-key` = the same client token) are the ones a plain web page already uses. This was verified end to end on dev: segments uploaded from an application of type `electron`, both direct and through a `ddforward` proxy, return `202`, land in S3 and in `t_replay_segments`, and the read endpoint hands back a presigned URL.

## The three condition changes

They are the only behavioral changes, each marked `FLASHCAT FORK (n/3)` in the code so the fork delta stays easy to spot if an upstream patch ever has to be picked.

1. **`packages/rum/src/boot/recorderApi.ts`** — the recorder is no longer disabled up front when a bridge is present without the `records` capability. That check moved from `makeRecorderApi()` into `onRumStart()`, because it now depends on a configuration option, and the configuration does not exist yet when `makeRecorderApi()` runs at module evaluation. `makeRecorderApi()` keeps only the browser support check; the resulting behavior for a host that does not opt in is unchanged (the strategy stays the pre-start one, so `isRecording()` is `false`, `getReplayStats()` and `getSessionReplayLink()` are `undefined`, and no worker is ever started).
2. **`packages/rum/src/boot/startRecording.ts`** — records go to `startSegmentCollection` (segment + upload) instead of `startRecordBridge` (hand over to the host).
3. **`packages/rum-core/src/domain/rumSessionManager.ts`** — the stub session is marked `SAMPLED`, so view events carry `session.has_replay`. That flag is what the read side keys on to expose the replay; without it the segments would be uploaded but never reachable.

## Session id and anonymous id

This is the part the approach stands or falls on.

With a bridge present, the page uses `startRumSessionManagerStub()`, whose session id is the hardcoded placeholder `00000000-aaaa-0000-aaaa-000000000000`. That is fine upstream because the host overwrites `session.id` on every RUM event it forwards — which our Electron main process does. **But nobody overwrites the session id of a replay segment**, since the segment is uploaded by the page directly. Segments are joined to a session by `(account, session id)`, so a placeholder id means the replay is stored and never associated with a real session.

The stub therefore reads the identifiers the host actually owns, through two new **optional** methods on the bridge:

```ts
getSessionId?(): string
getAnonymousId?(): string
```

Both are feature-detected: a host built against an older SDK does not implement them, and the page falls back to the placeholder session id and to no anonymous id, rather than crashing. The session id is read on every `findTrackedSession()` call, because the host renews it over time.

`getAnonymousId()` also fixes a second problem: the stub session had no `anonymousId` field at all, so `usr.anonymous_id` was always empty in a host application and unique user counts were always zero.

The host side of the contract is implemented and verified in flashcatcloud/fc-sdk-electron#11.

## Configuration

```ts
flashcatRum.init({
  applicationId: '...',
  clientToken: '...',
  sessionReplayDirectUpload: true,
  sessionReplaySampleRate: 100, // required, see below
})
```

`sessionReplaySampleRate` **defaults to 0**, and this option does not change that. Enabling `sessionReplayDirectUpload` alone records nothing. The sample rate is applied to the stub session as well, so it has to be set explicitly. This is called out in the option's TSDoc.

The option has no effect outside a host application: without a bridge the page already records and uploads Session Replay.

## Tests

New specs cover each branch:

- `recorderApi.spec.ts` — the recorder starts when the bridge does not support records but the option is set (the existing "should not start recording" case is untouched and still passes).
- `startRecording.spec.ts` — with a bridge present and the option set, segments are sent over the SDK's own request and nothing goes through `bridge.send`.
- `rumSessionManager.spec.ts` — the session is `SAMPLED` with the option set, `OFF` when `sessionReplaySampleRate` is 0; the bridge-provided session id and anonymous id are used, the placeholder is used when the bridge does not implement the methods or returns an empty string, and the session id is re-read on each call.

`mockEventBridge` gained optional `sessionId` / `anonymousId`; omitting them leaves the methods off the mock entirely, which is what emulates an older host.

No existing assertion was relaxed or removed. `configuration.spec.ts` was updated only to include the new key in the exhaustive `Required<RumInitConfiguration>` object (the option is not reported to telemetry).

## Pre-existing breakage in this repo (not from this PR)

`yarn test:unit`, `yarn lint` and `yarn typecheck` are **not clean on `main`**, and this branch does not change that: 42 failing specs, 318 lint problems and 18 type errors before and after. The failures come from stale fork drift, mostly `packages/rum/test/mockProfiler.ts` importing `registerCleanupTask` from `@flashcatcloud/browser-rum/test` and `getGlobalObject` from `@flashcatcloud/browser-rum` (they live in `browser-core`), which breaks module loading for ~13 spec files under `packages/rum`, plus `profiler.spec.ts` still importing `@datadog/*` package names and a `serializeRumConfiguration` spec expecting a `datadog` tracing propagator the fork removed. Fixing that is out of scope here; the new specs above were verified green by patching those imports locally and reverting the patch before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
