### PR TITLE
feat(rum): keep collecting Session Replay in the page when a host bridge is present

### DIFF
--- a/packages/core/src/transport/eventBridge.spec.ts
+++ b/packages/core/src/transport/eventBridge.spec.ts
@@ -56,6 +56,36 @@ describe('event bridge send', () => {
   })
 })
 
+// FLASHCAT FORK: identifiers owned by the host application. `undefined` (the host does not
+// implement the getter) and `''` (the host implements it and has no session right now) mean
+// different things and must not be collapsed into one another — see `DatadogEventBridge`.
+describe('event bridge getSessionId', () => {
+  it('should return the session id the host reports', () => {
+    mockEventBridge({ sessionId: 'host-session-id' })
+
+    expect(getEventBridge()!.getSessionId()).toBe('host-session-id')
+  })
+
+  it('should return undefined when the host does not implement the getter', () => {
+    mockEventBridge()
+
+    expect(getEventBridge()!.getSessionId()).toBeUndefined()
+  })
+
+  it('should return an empty string, not undefined, when the host has no session right now', () => {
+    mockEventBridge({ sessionId: '' })
+
+    expect(getEventBridge()!.getSessionId()).toBe('')
+  })
+
+  it('should normalise any other falsy answer from an implementing host to an empty string', () => {
+    const eventBridge = mockEventBridge({ sessionId: '' })
+    eventBridge.getSessionId = () => undefined as unknown as string
+
+    expect(getEventBridge()!.getSessionId()).toBe('')
+  })
+})
+
 describe('event bridge getPrivacyLevel', () => {
   const bridgePrivacyLevel = DefaultPrivacyLevel.MASK
 

--- a/packages/core/src/transport/eventBridge.ts
+++ b/packages/core/src/transport/eventBridge.ts
@@ -10,6 +10,17 @@ export interface DatadogEventBridge {
   getPrivacyLevel?(): DefaultPrivacyLevel
   getAllowedWebViewHosts(): string
   send(msg: string): void
+  /**
+   * FLASHCAT FORK: identifiers owned by the host application.
+   *
+   * Both are optional: hosts built against an older SDK do not implement them, in which case the
+   * web SDK falls back to its own placeholder values.
+   *
+   * They are expected to be synchronous: the host pushes updates to the bridge implementation
+   * (e.g. an Electron preload script), which caches them and answers from that cache.
+   */
+  getSessionId?(): string
+  getAnonymousId?(): string
 }
 
 export const enum BridgeCapability {
@@ -32,6 +43,13 @@ export function getEventBridge<T, E>() {
     },
     getAllowedWebViewHosts() {
       return JSON.parse(eventBridgeGlobal.getAllowedWebViewHosts()) as string[]
+    },
+    // FLASHCAT FORK: see `DatadogEventBridge`. Returns `undefined` when the host does not provide it.
+    getSessionId() {
+      return eventBridgeGlobal.getSessionId?.() || undefined
+    },
+    getAnonymousId() {
+      return eventBridgeGlobal.getAnonymousId?.() || undefined
     },
     send(eventType: T, event: E, viewId?: string) {
       const view = viewId ? { id: viewId } : undefined

--- a/packages/core/src/transport/eventBridge.ts
+++ b/packages/core/src/transport/eventBridge.ts
@@ -20,8 +20,14 @@ export interface DatadogEventBridge {
    * (e.g. an Electron preload script), which caches them and answers from that cache.
    *
    * An empty string means the host has no such identifier right now — a session that expired and
-   * has not been renewed, say — and is treated exactly like not implementing the method at all.
-   * A host with nothing to report must therefore answer `''`, never a made-up value.
+   * has not been renewed, say. A host with nothing to report must answer `''`, never a made-up
+   * value and never a stale one.
+   *
+   * "No identifier right now" is NOT the same thing as "this host does not implement the getter":
+   * the first is a real state of a host that owns the identifier, the second is an older host that
+   * leaves it to this SDK. Only the second may fall back to a placeholder — a host that answers
+   * `''` has told us there is nothing to attribute data to, and this page must stop attributing
+   * data until the host answers with an id again.
    */
   getSessionId?(): string
   getAnonymousId?(): string
@@ -48,10 +54,13 @@ export function getEventBridge<T, E>() {
     getAllowedWebViewHosts() {
       return JSON.parse(eventBridgeGlobal.getAllowedWebViewHosts()) as string[]
     },
-    // FLASHCAT FORK: see `DatadogEventBridge`. Returns `undefined` when the host does not provide
-    // it — `||` rather than `??` on purpose, so an empty answer means the same as no answer.
-    getSessionId() {
-      return eventBridgeGlobal.getSessionId?.() || undefined
+    // FLASHCAT FORK: see `DatadogEventBridge`. The two answers callers must tell apart:
+    // `undefined` — the host does not implement the getter and does not own the session id;
+    // `''`        — the host owns it and has no session right now.
+    // Anything falsy a host may return instead of `''` (a `null`, say) is normalised to `''`: it
+    // still comes from a host that implements the getter, so it still means "no session".
+    getSessionId(): string | undefined {
+      return eventBridgeGlobal.getSessionId ? eventBridgeGlobal.getSessionId() || '' : undefined
     },
     getAnonymousId() {
       return eventBridgeGlobal.getAnonymousId?.() || undefined

--- a/packages/core/src/transport/eventBridge.ts
+++ b/packages/core/src/transport/eventBridge.ts
@@ -18,6 +18,10 @@ export interface DatadogEventBridge {
    *
    * They are expected to be synchronous: the host pushes updates to the bridge implementation
    * (e.g. an Electron preload script), which caches them and answers from that cache.
+   *
+   * An empty string means the host has no such identifier right now — a session that expired and
+   * has not been renewed, say — and is treated exactly like not implementing the method at all.
+   * A host with nothing to report must therefore answer `''`, never a made-up value.
    */
   getSessionId?(): string
   getAnonymousId?(): string
@@ -44,7 +48,8 @@ export function getEventBridge<T, E>() {
     getAllowedWebViewHosts() {
       return JSON.parse(eventBridgeGlobal.getAllowedWebViewHosts()) as string[]
     },
-    // FLASHCAT FORK: see `DatadogEventBridge`. Returns `undefined` when the host does not provide it.
+    // FLASHCAT FORK: see `DatadogEventBridge`. Returns `undefined` when the host does not provide
+    // it — `||` rather than `??` on purpose, so an empty answer means the same as no answer.
     getSessionId() {
       return eventBridgeGlobal.getSessionId?.() || undefined
     },

--- a/packages/core/test/emulate/mockEventBridge.ts
+++ b/packages/core/test/emulate/mockEventBridge.ts
@@ -7,12 +7,24 @@ export function mockEventBridge({
   allowedWebViewHosts = [window.location.hostname],
   privacyLevel = DefaultPrivacyLevel.MASK,
   capabilities = [BridgeCapability.RECORDS],
-}: { allowedWebViewHosts?: string[]; privacyLevel?: DefaultPrivacyLevel; capabilities?: BridgeCapability[] } = {}) {
+  sessionId,
+  anonymousId,
+}: {
+  allowedWebViewHosts?: string[]
+  privacyLevel?: DefaultPrivacyLevel
+  capabilities?: BridgeCapability[]
+  // FLASHCAT FORK: host provided identifiers. When left out, the bridge does not implement the
+  // corresponding method at all, which emulates a host built against an older SDK.
+  sessionId?: string
+  anonymousId?: string
+} = {}) {
   const eventBridge: DatadogEventBridge = {
     send: (_msg: string) => undefined,
     getAllowedWebViewHosts: () => JSON.stringify(allowedWebViewHosts),
     getCapabilities: () => JSON.stringify(capabilities),
     getPrivacyLevel: () => privacyLevel,
+    ...(sessionId !== undefined ? { getSessionId: () => sessionId } : {}),
+    ...(anonymousId !== undefined ? { getAnonymousId: () => anonymousId } : {}),
   }
 
   ;(window as BrowserWindowWithEventBridge).DatadogEventBridge = eventBridge

--- a/packages/rum-core/src/boot/preStartRum.spec.ts
+++ b/packages/rum-core/src/boot/preStartRum.spec.ts
@@ -158,6 +158,26 @@ describe('preStartRum', () => {
         strategy.init(DEFAULT_INIT_CONFIGURATION, PUBLIC_API)
         expect(doStartRumSpy).toHaveBeenCalled()
       })
+
+      // FLASHCAT FORK (4/4) - see `sessionReplayDirectUpload` in RumInitConfiguration.
+      it('should replace the intake credentials with placeholders by default', () => {
+        mockEventBridge()
+        strategy.init({ applicationId: 'real-app-id', clientToken: 'real-client-token' }, PUBLIC_API)
+
+        expect(strategy.initConfiguration?.applicationId).toBe('00000000-aaaa-0000-aaaa-000000000000')
+        expect(strategy.initConfiguration?.clientToken).toBe('empty')
+      })
+
+      it('should keep the intake credentials when sessionReplayDirectUpload is set', () => {
+        mockEventBridge()
+        strategy.init(
+          { applicationId: 'real-app-id', clientToken: 'real-client-token', sessionReplayDirectUpload: true },
+          PUBLIC_API
+        )
+
+        expect(strategy.initConfiguration?.applicationId).toBe('real-app-id')
+        expect(strategy.initConfiguration?.clientToken).toBe('real-client-token')
+      })
     })
   })
 

--- a/packages/rum-core/src/boot/preStartRum.ts
+++ b/packages/rum-core/src/boot/preStartRum.ts
@@ -253,10 +253,17 @@ export function createPreStartStrategy(
 }
 
 function overrideInitConfigurationForBridge(initConfiguration: RumInitConfiguration): RumInitConfiguration {
+  // FLASHCAT FORK (4/4) - see `sessionReplayDirectUpload` in RumInitConfiguration.
+  // Upstream replaces the credentials with placeholders, because a page hosting a bridge is assumed
+  // never to send a request of its own. `sessionReplayDirectUpload` breaks that assumption: the page
+  // uploads Session Replay segments over HTTP, and the intake authenticates them with the client
+  // token and stores them under the application id. Both have to survive for those uploads to be
+  // accepted. RUM events are unaffected either way, as they go through `bridge.send()`, never HTTP.
+  const keepIntakeCredentials = !!initConfiguration.sessionReplayDirectUpload
   return {
     ...initConfiguration,
-    applicationId: '00000000-aaaa-0000-aaaa-000000000000',
-    clientToken: 'empty',
+    applicationId: keepIntakeCredentials ? initConfiguration.applicationId : '00000000-aaaa-0000-aaaa-000000000000',
+    clientToken: keepIntakeCredentials ? initConfiguration.clientToken : 'empty',
     sessionSampleRate: 100,
     defaultPrivacyLevel: initConfiguration.defaultPrivacyLevel ?? getEventBridge()?.getPrivacyLevel(),
   }

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -28,6 +28,7 @@ import { startActionCollection } from '../domain/action/actionCollection'
 import { startErrorCollection } from '../domain/error/errorCollection'
 import { startResourceCollection } from '../domain/resource/resourceCollection'
 import { startViewCollection } from '../domain/view/viewCollection'
+import type { RumSessionManager } from '../domain/rumSessionManager'
 import { startRumSessionManager, startRumSessionManagerStub } from '../domain/rumSessionManager'
 import { startRumBatch } from '../transport/startRumBatch'
 import { startRumEventBridge } from '../transport/startRumEventBridge'
@@ -113,9 +114,15 @@ export function startRum(
   })
   cleanupTasks.push(() => pageActivationSubscription.unsubscribe())
 
-  const session = !canUseEventBridge()
-    ? startRumSessionManager(configuration, lifeCycle, trackingConsentState)
-    : startRumSessionManagerStub(configuration)
+  let session: RumSessionManager
+  if (!canUseEventBridge()) {
+    session = startRumSessionManager(configuration, lifeCycle, trackingConsentState)
+  } else {
+    // FLASHCAT FORK - the stub watches the host application's session, so it owns a timer to stop.
+    const sessionStub = startRumSessionManagerStub(configuration, lifeCycle)
+    cleanupTasks.push(sessionStub.stop)
+    session = sessionStub
+  }
 
   if (!canUseEventBridge()) {
     const batch = startRumBatch(

--- a/packages/rum-core/src/boot/startRum.ts
+++ b/packages/rum-core/src/boot/startRum.ts
@@ -115,7 +115,7 @@ export function startRum(
 
   const session = !canUseEventBridge()
     ? startRumSessionManager(configuration, lifeCycle, trackingConsentState)
-    : startRumSessionManagerStub()
+    : startRumSessionManagerStub(configuration)
 
   if (!canUseEventBridge()) {
     const batch = startRumBatch(

--- a/packages/rum-core/src/domain/configuration/configuration.spec.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.spec.ts
@@ -554,6 +554,7 @@ describe('serializeRumConfiguration', () => {
       subdomain: 'foo',
       sessionReplaySampleRate: 60,
       startSessionReplayRecordingManually: true,
+      sessionReplayDirectUpload: true,
       trackUserInteractions: true,
       actionNameAttribute: 'test-id',
       trackViewsManually: true,
@@ -580,6 +581,8 @@ describe('serializeRumConfiguration', () => {
                 | 'profilingSampleRate'
                 | 'propagateTraceBaggage'
                 | 'trackWebVitals'
+                // FLASHCAT FORK: not reported to telemetry
+                | 'sessionReplayDirectUpload'
             ? never
             : CamelToSnakeCase<Key>
     // By specifying the type here, we can ensure that serializeConfiguration is returning an

--- a/packages/rum-core/src/domain/configuration/configuration.ts
+++ b/packages/rum-core/src/domain/configuration/configuration.ts
@@ -105,6 +105,24 @@ export interface RumInitConfiguration extends InitConfiguration {
    * See [Session Replay Usage](https://docs.datadoghq.com/real_user_monitoring/session_replay/browser/#usage) for further information.
    */
   startSessionReplayRecordingManually?: boolean | undefined
+  /**
+   * When the SDK runs inside a host application that injects an event bridge (an Electron renderer
+   * process, a mobile WebView...), Session Replay is normally handed over to the host application,
+   * and is not collected at all when the host does not implement it.
+   *
+   * Set this to `true` to keep collecting Session Replay in the page and upload it from here, over
+   * the same intake connection a regular web page uses. Use it when the host application does not
+   * record Session Replay itself.
+   *
+   * This has no effect outside of a host application (no event bridge), where Session Replay is
+   * always collected and uploaded by this SDK.
+   *
+   * Note: `sessionReplaySampleRate` defaults to 0, so it must be set explicitly as well, otherwise
+   * nothing is recorded.
+   *
+   * @default false
+   */
+  sessionReplayDirectUpload?: boolean | undefined
 
   /**
    * Enables privacy control for action names.
@@ -184,6 +202,7 @@ export interface RumConfiguration extends Configuration {
   enablePrivacyForActionName: boolean
   sessionReplaySampleRate: number
   startSessionReplayRecordingManually: boolean
+  sessionReplayDirectUpload: boolean
   trackUserInteractions: boolean
   trackViewsManually: boolean
   trackWebVitals: boolean
@@ -249,6 +268,7 @@ export function validateAndBuildRumConfiguration(
       initConfiguration.startSessionReplayRecordingManually !== undefined
         ? !!initConfiguration.startSessionReplayRecordingManually
         : sessionReplaySampleRate === 0,
+    sessionReplayDirectUpload: !!initConfiguration.sessionReplayDirectUpload,
     traceSampleRate: initConfiguration.traceSampleRate ?? 100,
     rulePsr: isNumber(initConfiguration.traceSampleRate) ? initConfiguration.traceSampleRate / 100 : undefined,
     allowedTracingUrls,

--- a/packages/rum-core/src/domain/contexts/userContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/userContext.spec.ts
@@ -88,7 +88,7 @@ describe('user context', () => {
       })
     })
 
-    // FLASHCAT FORK (4/4) - see `sessionReplayDirectUpload` in RumInitConfiguration.
+    // FLASHCAT FORK - see `getAnonymousId` in `DatadogEventBridge`.
     describe('when a host application provides the anonymous id', () => {
       it('should not backfill the user id, but still set anonymous_id', () => {
         mockEventBridge()

--- a/packages/rum-core/src/domain/contexts/userContext.spec.ts
+++ b/packages/rum-core/src/domain/contexts/userContext.spec.ts
@@ -1,6 +1,6 @@
 import type { ContextManager, RelativeTime } from '@flashcatcloud/browser-core'
 import { HookNames, removeStorageListeners } from '@flashcatcloud/browser-core'
-import { registerCleanupTask } from '@flashcatcloud/browser-core/test'
+import { mockEventBridge, registerCleanupTask } from '@flashcatcloud/browser-core/test'
 import { createRumSessionManagerMock, mockRumConfiguration } from '../../../test'
 import type { Hooks } from '../hooks'
 import { createHooks } from '../hooks'
@@ -64,6 +64,72 @@ describe('user context', () => {
           id: '123',
           anonymous_id: 'device-123',
         },
+      })
+    })
+
+    // FLASHCAT FORK - pins the web behavior the bridge case below deviates from.
+    it('should backfill the user id with the anonymous id when no user is set', () => {
+      userContext = startUserContext(
+        hooks,
+        mockRumConfiguration({ trackAnonymousUser: true }),
+        createRumSessionManagerMock()
+      )
+      const defaultRumEventAttributes = hooks.triggerHook(HookNames.Assemble, {
+        eventType: 'view',
+        startTime: 0 as RelativeTime,
+      })
+
+      expect(defaultRumEventAttributes).toEqual({
+        type: 'view',
+        usr: {
+          id: 'device-123',
+          anonymous_id: 'device-123',
+        },
+      })
+    })
+
+    // FLASHCAT FORK (4/4) - see `sessionReplayDirectUpload` in RumInitConfiguration.
+    describe('when a host application provides the anonymous id', () => {
+      it('should not backfill the user id, but still set anonymous_id', () => {
+        mockEventBridge()
+        userContext = startUserContext(
+          hooks,
+          mockRumConfiguration({ trackAnonymousUser: true }),
+          createRumSessionManagerMock()
+        )
+        const defaultRumEventAttributes = hooks.triggerHook(HookNames.Assemble, {
+          eventType: 'view',
+          startTime: 0 as RelativeTime,
+        })
+
+        expect(defaultRumEventAttributes).toEqual({
+          type: 'view',
+          usr: {
+            anonymous_id: 'device-123',
+          },
+        })
+      })
+
+      it('should leave a customer provided user id untouched', () => {
+        mockEventBridge()
+        userContext = startUserContext(
+          hooks,
+          mockRumConfiguration({ trackAnonymousUser: true }),
+          createRumSessionManagerMock()
+        )
+        userContext.setContext({ id: '123' })
+        const defaultRumEventAttributes = hooks.triggerHook(HookNames.Assemble, {
+          eventType: 'view',
+          startTime: 0 as RelativeTime,
+        })
+
+        expect(defaultRumEventAttributes).toEqual({
+          type: 'view',
+          usr: {
+            id: '123',
+            anonymous_id: 'device-123',
+          },
+        })
       })
     })
 

--- a/packages/rum-core/src/domain/contexts/userContext.ts
+++ b/packages/rum-core/src/domain/contexts/userContext.ts
@@ -18,7 +18,7 @@ export function startUserContext(hooks: Hooks, configuration: RumConfiguration, 
     storeContextManager(configuration, userContextManager, 'rum', CustomerDataType.User)
   }
 
-  // FLASHCAT FORK (4/4) - see `sessionReplayDirectUpload` in RumInitConfiguration.
+  // FLASHCAT FORK - see `getAnonymousId` in `DatadogEventBridge`.
   // Whether the anonymous id belongs to us or to a host application. Evaluated once: a bridge is
   // injected before any page script runs, so its presence cannot change afterwards.
   const hasHostProvidedAnonymousId = canUseEventBridge()
@@ -28,7 +28,7 @@ export function startUserContext(hooks: Hooks, configuration: RumConfiguration, 
     const session = sessionManager.findTrackedSession(startTime)
 
     if (session && session.anonymousId && !user.anonymous_id && !!configuration.trackAnonymousUser) {
-      // FLASHCAT FORK (4/4) - the copy into `user.id` is a Flashcat addition, not upstream: on the
+      // FLASHCAT FORK - the copy into `user.id` is a Flashcat addition, not upstream: on the
       // web it is what makes unique users countable, because that baseline only counts `usr.id` and
       // would otherwise miss every logged-out visitor.
       //

--- a/packages/rum-core/src/domain/contexts/userContext.ts
+++ b/packages/rum-core/src/domain/contexts/userContext.ts
@@ -1,5 +1,6 @@
 import {
   SKIPPED,
+  canUseEventBridge,
   createContextManager,
   CustomerDataType,
   HookNames,
@@ -17,12 +18,30 @@ export function startUserContext(hooks: Hooks, configuration: RumConfiguration, 
     storeContextManager(configuration, userContextManager, 'rum', CustomerDataType.User)
   }
 
+  // FLASHCAT FORK (4/4) - see `sessionReplayDirectUpload` in RumInitConfiguration.
+  // Whether the anonymous id belongs to us or to a host application. Evaluated once: a bridge is
+  // injected before any page script runs, so its presence cannot change afterwards.
+  const hasHostProvidedAnonymousId = canUseEventBridge()
+
   hooks.register(HookNames.Assemble, ({ eventType, startTime }): DefaultRumEventAttributes | SKIPPED => {
     const user = userContextManager.getContext()
     const session = sessionManager.findTrackedSession(startTime)
 
     if (session && session.anonymousId && !user.anonymous_id && !!configuration.trackAnonymousUser) {
-      user.id = isEmptyObject(user) ? session.anonymousId : user.id
+      // FLASHCAT FORK (4/4) - the copy into `user.id` is a Flashcat addition, not upstream: on the
+      // web it is what makes unique users countable, because that baseline only counts `usr.id` and
+      // would otherwise miss every logged-out visitor.
+      //
+      // A host application does not need it and is harmed by it. Its baseline already prefers the
+      // anonymous id (`COALESCE(usr_anonymous_id, usr_id)`), and that id is stable across logins,
+      // so copying it into `usr.id` adds nothing while importing the web double-counting bug, where
+      // one device is counted as two users before and after a login. `fc-sdk-electron` deliberately
+      // does not backfill on the main process side; this keeps the renderer process consistent.
+      //
+      // Web behavior is untouched: without a bridge this is the original line.
+      if (!hasHostProvidedAnonymousId) {
+        user.id = isEmptyObject(user) ? session.anonymousId : user.id
+      }
       user.anonymous_id = session.anonymousId
     }
 

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -226,18 +226,26 @@ describe('rum session manager', () => {
 })
 
 describe('rum session manager stub', () => {
+  let lifeCycle: LifeCycle
+
+  beforeEach(() => {
+    lifeCycle = new LifeCycle()
+  })
+
+  function startStub(configuration: RumConfiguration = mockRumConfiguration()) {
+    const sessionManager = startRumSessionManagerStub(configuration, lifeCycle)
+    registerCleanupTask(sessionManager.stop)
+    return sessionManager
+  }
+
   it('should return a tracked session with replay allowed when the event bridge support records', () => {
     mockEventBridge({ capabilities: [BridgeCapability.RECORDS] })
-    expect(startRumSessionManagerStub(mockRumConfiguration()).findTrackedSession()!.sessionReplay).toEqual(
-      SessionReplayState.SAMPLED
-    )
+    expect(startStub().findTrackedSession()!.sessionReplay).toEqual(SessionReplayState.SAMPLED)
   })
 
   it('should return a tracked session without replay allowed when the event bridge support records', () => {
     mockEventBridge({ capabilities: [] })
-    expect(startRumSessionManagerStub(mockRumConfiguration()).findTrackedSession()!.sessionReplay).toEqual(
-      SessionReplayState.OFF
-    )
+    expect(startStub().findTrackedSession()!.sessionReplay).toEqual(SessionReplayState.OFF)
   })
 
   // FLASHCAT FORK - see `sessionReplayDirectUpload` in RumInitConfiguration.
@@ -245,17 +253,13 @@ describe('rum session manager stub', () => {
     it('should return a tracked session with replay allowed even when the bridge does not support records', () => {
       mockEventBridge({ capabilities: [] })
       const configuration = mockRumConfiguration({ sessionReplayDirectUpload: true, sessionReplaySampleRate: 100 })
-      expect(startRumSessionManagerStub(configuration).findTrackedSession()!.sessionReplay).toEqual(
-        SessionReplayState.SAMPLED
-      )
+      expect(startStub(configuration).findTrackedSession()!.sessionReplay).toEqual(SessionReplayState.SAMPLED)
     })
 
     it('should honor sessionReplaySampleRate', () => {
       mockEventBridge({ capabilities: [] })
       const configuration = mockRumConfiguration({ sessionReplayDirectUpload: true, sessionReplaySampleRate: 0 })
-      expect(startRumSessionManagerStub(configuration).findTrackedSession()!.sessionReplay).toEqual(
-        SessionReplayState.OFF
-      )
+      expect(startStub(configuration).findTrackedSession()!.sessionReplay).toEqual(SessionReplayState.OFF)
     })
   })
 
@@ -263,21 +267,14 @@ describe('rum session manager stub', () => {
   describe('host provided identifiers', () => {
     it('should use the session id and the anonymous id provided by the bridge', () => {
       mockEventBridge({ sessionId: 'host-session-id', anonymousId: 'host-anonymous-id' })
-      const session = startRumSessionManagerStub(mockRumConfiguration()).findTrackedSession()!
+      const session = startStub().findTrackedSession()!
       expect(session.id).toBe('host-session-id')
       expect(session.anonymousId).toBe('host-anonymous-id')
     })
 
     it('should fall back to the placeholder session id when the bridge does not implement the methods', () => {
       mockEventBridge()
-      const session = startRumSessionManagerStub(mockRumConfiguration()).findTrackedSession()!
-      expect(session.id).toBe(STUB_SESSION_ID)
-      expect(session.anonymousId).toBeUndefined()
-    })
-
-    it('should fall back to the placeholder session id when the bridge returns an empty session id', () => {
-      mockEventBridge({ sessionId: '', anonymousId: '' })
-      const session = startRumSessionManagerStub(mockRumConfiguration()).findTrackedSession()!
+      const session = startStub().findTrackedSession()!
       expect(session.id).toBe(STUB_SESSION_ID)
       expect(session.anonymousId).toBeUndefined()
     })
@@ -287,11 +284,146 @@ describe('rum session manager stub', () => {
       const eventBridge = mockEventBridge({ sessionId: '' })
       eventBridge.getSessionId = () => sessionId
 
-      const sessionManager = startRumSessionManagerStub(mockRumConfiguration())
+      const sessionManager = startStub()
       expect(sessionManager.findTrackedSession()!.id).toBe('first-session-id')
 
       sessionId = 'renewed-session-id'
       expect(sessionManager.findTrackedSession()!.id).toBe('renewed-session-id')
+    })
+  })
+
+  // FLASHCAT FORK - a host that answers for the session id and reports none has no session at all
+  // right now. Falling back to the placeholder here would attribute this page's Session Replay
+  // segments — which it uploads itself, bypassing the host — to a fake session shared by every
+  // application, and reusing the previous id would attribute them to a session that has ended.
+  describe('when the host reports no session', () => {
+    it('should report no tracked session', () => {
+      mockEventBridge({ sessionId: '', anonymousId: '' })
+
+      expect(startStub().findTrackedSession()).toBeUndefined()
+    })
+
+    it('should not fall back to the placeholder session id', () => {
+      mockEventBridge({ sessionId: '' })
+
+      expect(startStub().findTrackedSession()?.id).not.toBe(STUB_SESSION_ID)
+    })
+
+    it('should report a tracked session again once the host renews it', () => {
+      let sessionId = ''
+      const eventBridge = mockEventBridge({ sessionId: '' })
+      eventBridge.getSessionId = () => sessionId
+      const sessionManager = startStub()
+
+      expect(sessionManager.findTrackedSession()).toBeUndefined()
+
+      sessionId = 'renewed-session-id'
+      expect(sessionManager.findTrackedSession()!.id).toBe('renewed-session-id')
+    })
+  })
+
+  // FLASHCAT FORK - the bridge is pull-only, so the stub polls it the way the regular session
+  // manager polls its own store, and turns what it sees into the same lifecycle events. Without
+  // them the recorder would keep a segment open across the end of the host session.
+  describe('watching the host session', () => {
+    let clock: Clock
+    let expireSessionSpy: jasmine.Spy
+    let renewSessionSpy: jasmine.Spy
+    let hostSessionId: string
+
+    beforeEach(() => {
+      clock = mockClock()
+      registerCleanupTask(clock.cleanup)
+      expireSessionSpy = jasmine.createSpy('expireSessionSpy')
+      renewSessionSpy = jasmine.createSpy('renewSessionSpy')
+      lifeCycle.subscribe(LifeCycleEventType.SESSION_EXPIRED, expireSessionSpy)
+      lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, renewSessionSpy)
+    })
+
+    function mockHostSession(initialSessionId: string) {
+      hostSessionId = initialSessionId
+      const eventBridge = mockEventBridge({ sessionId: initialSessionId })
+      eventBridge.getSessionId = () => hostSessionId
+    }
+
+    it('should notify SESSION_EXPIRED when the host session expires', () => {
+      mockHostSession('host-session-id')
+      startStub()
+
+      hostSessionId = ''
+      clock.tick(STORAGE_POLL_DELAY)
+
+      expect(expireSessionSpy).toHaveBeenCalledTimes(1)
+      expect(renewSessionSpy).not.toHaveBeenCalled()
+    })
+
+    it('should notify SESSION_RENEWED when the host starts a new session', () => {
+      mockHostSession('')
+      startStub()
+
+      hostSessionId = 'renewed-session-id'
+      clock.tick(STORAGE_POLL_DELAY)
+
+      expect(renewSessionSpy).toHaveBeenCalledTimes(1)
+      expect(expireSessionSpy).not.toHaveBeenCalled()
+    })
+
+    it('should notify both when the host swaps one session for another without reporting a gap', () => {
+      mockHostSession('first-session-id')
+      startStub()
+
+      hostSessionId = 'second-session-id'
+      clock.tick(STORAGE_POLL_DELAY)
+
+      expect(expireSessionSpy).toHaveBeenCalledTimes(1)
+      expect(renewSessionSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should already answer with the new session when it notifies', () => {
+      mockHostSession('first-session-id')
+      const sessionManager = startStub()
+      const idsSeenBySubscribers: Array<string | undefined> = []
+      lifeCycle.subscribe(LifeCycleEventType.SESSION_EXPIRED, () => {
+        idsSeenBySubscribers.push(sessionManager.findTrackedSession()?.id)
+      })
+      lifeCycle.subscribe(LifeCycleEventType.SESSION_RENEWED, () => {
+        idsSeenBySubscribers.push(sessionManager.findTrackedSession()?.id)
+      })
+
+      hostSessionId = 'second-session-id'
+      clock.tick(STORAGE_POLL_DELAY)
+
+      expect(idsSeenBySubscribers).toEqual(['second-session-id', 'second-session-id'])
+    })
+
+    it('should not notify anything while the host session does not change', () => {
+      mockHostSession('host-session-id')
+      startStub()
+
+      clock.tick(10 * STORAGE_POLL_DELAY)
+
+      expect(expireSessionSpy).not.toHaveBeenCalled()
+      expect(renewSessionSpy).not.toHaveBeenCalled()
+    })
+
+    it('should not watch a host that does not answer for the session id', () => {
+      mockEventBridge()
+      startStub()
+
+      clock.tick(10 * STORAGE_POLL_DELAY)
+
+      expect(expireSessionSpy).not.toHaveBeenCalled()
+      expect(renewSessionSpy).not.toHaveBeenCalled()
+    })
+
+    it('should stop watching once stopped', () => {
+      mockHostSession('host-session-id')
+      startRumSessionManagerStub(mockRumConfiguration(), lifeCycle).stop()
+
+      hostSessionId = ''
+      clock.tick(10 * STORAGE_POLL_DELAY)
+
+      expect(expireSessionSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/rum-core/src/domain/rumSessionManager.spec.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.spec.ts
@@ -27,6 +27,7 @@ import {
   RUM_SESSION_KEY,
   RumTrackingType,
   SessionReplayState,
+  STUB_SESSION_ID,
   startRumSessionManager,
   startRumSessionManagerStub,
 } from './rumSessionManager'
@@ -227,11 +228,70 @@ describe('rum session manager', () => {
 describe('rum session manager stub', () => {
   it('should return a tracked session with replay allowed when the event bridge support records', () => {
     mockEventBridge({ capabilities: [BridgeCapability.RECORDS] })
-    expect(startRumSessionManagerStub().findTrackedSession()!.sessionReplay).toEqual(SessionReplayState.SAMPLED)
+    expect(startRumSessionManagerStub(mockRumConfiguration()).findTrackedSession()!.sessionReplay).toEqual(
+      SessionReplayState.SAMPLED
+    )
   })
 
   it('should return a tracked session without replay allowed when the event bridge support records', () => {
     mockEventBridge({ capabilities: [] })
-    expect(startRumSessionManagerStub().findTrackedSession()!.sessionReplay).toEqual(SessionReplayState.OFF)
+    expect(startRumSessionManagerStub(mockRumConfiguration()).findTrackedSession()!.sessionReplay).toEqual(
+      SessionReplayState.OFF
+    )
+  })
+
+  // FLASHCAT FORK - see `sessionReplayDirectUpload` in RumInitConfiguration.
+  describe('with sessionReplayDirectUpload', () => {
+    it('should return a tracked session with replay allowed even when the bridge does not support records', () => {
+      mockEventBridge({ capabilities: [] })
+      const configuration = mockRumConfiguration({ sessionReplayDirectUpload: true, sessionReplaySampleRate: 100 })
+      expect(startRumSessionManagerStub(configuration).findTrackedSession()!.sessionReplay).toEqual(
+        SessionReplayState.SAMPLED
+      )
+    })
+
+    it('should honor sessionReplaySampleRate', () => {
+      mockEventBridge({ capabilities: [] })
+      const configuration = mockRumConfiguration({ sessionReplayDirectUpload: true, sessionReplaySampleRate: 0 })
+      expect(startRumSessionManagerStub(configuration).findTrackedSession()!.sessionReplay).toEqual(
+        SessionReplayState.OFF
+      )
+    })
+  })
+
+  // FLASHCAT FORK - the host application owns the session id and the anonymous id.
+  describe('host provided identifiers', () => {
+    it('should use the session id and the anonymous id provided by the bridge', () => {
+      mockEventBridge({ sessionId: 'host-session-id', anonymousId: 'host-anonymous-id' })
+      const session = startRumSessionManagerStub(mockRumConfiguration()).findTrackedSession()!
+      expect(session.id).toBe('host-session-id')
+      expect(session.anonymousId).toBe('host-anonymous-id')
+    })
+
+    it('should fall back to the placeholder session id when the bridge does not implement the methods', () => {
+      mockEventBridge()
+      const session = startRumSessionManagerStub(mockRumConfiguration()).findTrackedSession()!
+      expect(session.id).toBe(STUB_SESSION_ID)
+      expect(session.anonymousId).toBeUndefined()
+    })
+
+    it('should fall back to the placeholder session id when the bridge returns an empty session id', () => {
+      mockEventBridge({ sessionId: '', anonymousId: '' })
+      const session = startRumSessionManagerStub(mockRumConfiguration()).findTrackedSession()!
+      expect(session.id).toBe(STUB_SESSION_ID)
+      expect(session.anonymousId).toBeUndefined()
+    })
+
+    it('should read the session id again on each call, as the host renews it', () => {
+      let sessionId = 'first-session-id'
+      const eventBridge = mockEventBridge({ sessionId: '' })
+      eventBridge.getSessionId = () => sessionId
+
+      const sessionManager = startRumSessionManagerStub(mockRumConfiguration())
+      expect(sessionManager.findTrackedSession()!.id).toBe('first-session-id')
+
+      sessionId = 'renewed-session-id'
+      expect(sessionManager.findTrackedSession()!.id).toBe('renewed-session-id')
+    })
   })
 })

--- a/packages/rum-core/src/domain/rumSessionManager.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.ts
@@ -3,6 +3,7 @@ import {
   BridgeCapability,
   Observable,
   bridgeSupports,
+  getEventBridge,
   noop,
   performDraw,
   startSessionManager,
@@ -96,15 +97,35 @@ export function startRumSessionManager(
 }
 
 /**
+ * Session id used when the host application does not provide one. The host application is expected
+ * to override the session id of the events it forwards, so the placeholder never reaches the intake
+ * for RUM events. It does reach the intake for Session Replay segments, which are uploaded by this
+ * page directly, hence the `getSessionId()` lookup below.
+ */
+export const STUB_SESSION_ID = '00000000-aaaa-0000-aaaa-000000000000'
+
+/**
  * Start a tracked replay session stub
  */
-export function startRumSessionManagerStub(): RumSessionManager {
-  const session: RumSession = {
-    id: '00000000-aaaa-0000-aaaa-000000000000',
-    sessionReplay: bridgeSupports(BridgeCapability.RECORDS) ? SessionReplayState.SAMPLED : SessionReplayState.OFF,
-  }
+export function startRumSessionManagerStub(configuration: RumConfiguration): RumSessionManager {
+  // FLASHCAT FORK (3/3) - see `sessionReplayDirectUpload` in RumInitConfiguration.
+  // Session Replay segments uploaded from this page are joined to a session by `(account, session
+  // id)`, so they need the session id the host application actually uses, not the placeholder.
+  // `getSessionId()`/`getAnonymousId()` are absent on older host SDKs, hence the fallbacks.
+  const bridge = getEventBridge()
+  const sessionReplay =
+    bridgeSupports(BridgeCapability.RECORDS) ||
+    (configuration.sessionReplayDirectUpload && performDraw(configuration.sessionReplaySampleRate))
+      ? SessionReplayState.SAMPLED
+      : SessionReplayState.OFF
+
   return {
-    findTrackedSession: () => session,
+    // Read from the bridge on each call: the host application renews its session id over time.
+    findTrackedSession: (): RumSession => ({
+      id: bridge?.getSessionId() ?? STUB_SESSION_ID,
+      sessionReplay,
+      anonymousId: bridge?.getAnonymousId(),
+    }),
     expire: noop,
     expireObservable: new Observable(),
     setForcedReplay: noop,

--- a/packages/rum-core/src/domain/rumSessionManager.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.ts
@@ -108,11 +108,15 @@ export const STUB_SESSION_ID = '00000000-aaaa-0000-aaaa-000000000000'
  * Start a tracked replay session stub
  */
 export function startRumSessionManagerStub(configuration: RumConfiguration): RumSessionManager {
-  // FLASHCAT FORK (3/3) - see `sessionReplayDirectUpload` in RumInitConfiguration.
-  // Session Replay segments uploaded from this page are joined to a session by `(account, session
-  // id)`, so they need the session id the host application actually uses, not the placeholder.
-  // `getSessionId()`/`getAnonymousId()` are absent on older host SDKs, hence the fallbacks.
+  // FLASHCAT FORK - the host application owns the session id and the anonymous id, and answers for
+  // them through `DatadogEventBridge`. Both getters are absent on hosts built against an older SDK,
+  // hence the fallbacks below.
   const bridge = getEventBridge()
+
+  // FLASHCAT FORK (3/4) - see `sessionReplayDirectUpload` in RumInitConfiguration.
+  // Upstream only ever samples the stub for replay when the host declares the `records` capability,
+  // meaning the host records for us. With the option, this page records itself, so the draw is ours
+  // to make.
   const sessionReplay =
     bridgeSupports(BridgeCapability.RECORDS) ||
     (configuration.sessionReplayDirectUpload && performDraw(configuration.sessionReplaySampleRate))

--- a/packages/rum-core/src/domain/rumSessionManager.ts
+++ b/packages/rum-core/src/domain/rumSessionManager.ts
@@ -2,10 +2,13 @@ import type { RelativeTime, TrackingConsentState } from '@flashcatcloud/browser-
 import {
   BridgeCapability,
   Observable,
+  STORAGE_POLL_DELAY,
   bridgeSupports,
+  clearInterval,
   getEventBridge,
   noop,
   performDraw,
+  setInterval,
   startSessionManager,
 } from '@flashcatcloud/browser-core'
 import type { RumConfiguration } from './configuration'
@@ -97,17 +100,33 @@ export function startRumSessionManager(
 }
 
 /**
- * Session id used when the host application does not provide one. The host application is expected
- * to override the session id of the events it forwards, so the placeholder never reaches the intake
- * for RUM events. It does reach the intake for Session Replay segments, which are uploaded by this
- * page directly, hence the `getSessionId()` lookup below.
+ * Session id used when the host application does not answer for one, because it was built against
+ * an SDK that predates `getSessionId()`. Such a host is expected to override the session id of the
+ * events it forwards, so the placeholder never reaches the intake for RUM events.
+ *
+ * It would reach the intake for Session Replay segments, which this page uploads directly, and the
+ * placeholder is a constant shared by every application — so a host that DOES answer for the
+ * session id must never end up on it. See `startRumSessionManagerStub`.
  */
 export const STUB_SESSION_ID = '00000000-aaaa-0000-aaaa-000000000000'
 
 /**
+ * What `getSessionId()` answers when the host application owns the session id and has none right
+ * now. Distinct from `undefined`, which is a host that does not answer for it at all.
+ */
+const NO_HOST_SESSION = ''
+
+export interface RumSessionManagerStub extends RumSessionManager {
+  stop: () => void
+}
+
+/**
  * Start a tracked replay session stub
  */
-export function startRumSessionManagerStub(configuration: RumConfiguration): RumSessionManager {
+export function startRumSessionManagerStub(
+  configuration: RumConfiguration,
+  lifeCycle: LifeCycle
+): RumSessionManagerStub {
   // FLASHCAT FORK - the host application owns the session id and the anonymous id, and answers for
   // them through `DatadogEventBridge`. Both getters are absent on hosts built against an older SDK,
   // hence the fallbacks below.
@@ -123,16 +142,65 @@ export function startRumSessionManagerStub(configuration: RumConfiguration): Rum
       ? SessionReplayState.SAMPLED
       : SessionReplayState.OFF
 
+  const expireObservable = new Observable<void>()
+  expireObservable.subscribe(() => lifeCycle.notify(LifeCycleEventType.SESSION_EXPIRED))
+
+  // FLASHCAT FORK - the host session ends and is renewed while this page keeps running, and the
+  // bridge is pull-only: reading it again is the only way to notice. That is how the regular
+  // session manager learns the same thing — it polls its own store every `STORAGE_POLL_DELAY` and
+  // turns the transitions it sees into expire/renew notifications — so the stub mirrors it here
+  // rather than inventing a second lifecycle. Everything already subscribed to those two events
+  // then does the right thing: the recorder flushes its pending segment and stops, and starts
+  // again on a fresh view (and so a fresh full snapshot) once the host has a session again.
+  let lastSeenSessionId = readHostSessionId()
+  const watchIntervalId =
+    lastSeenSessionId === undefined
+      ? undefined
+      : setInterval(() => {
+          const sessionId = readHostSessionId()!
+          if (sessionId === lastSeenSessionId) {
+            return
+          }
+          const hadSession = lastSeenSessionId !== NO_HOST_SESSION
+          lastSeenSessionId = sessionId
+          // A host may go straight from one session to the next without ever reporting a gap, so
+          // both notifications can fire in the same tick. Order matters: subscribers read the
+          // session back, and by now the bridge already answers with the new one.
+          if (hadSession) {
+            expireObservable.notify()
+          }
+          if (sessionId !== NO_HOST_SESSION) {
+            lifeCycle.notify(LifeCycleEventType.SESSION_RENEWED)
+          }
+        }, STORAGE_POLL_DELAY)
+
+  function readHostSessionId() {
+    return bridge?.getSessionId()
+  }
+
   return {
-    // Read from the bridge on each call: the host application renews its session id over time.
-    findTrackedSession: (): RumSession => ({
-      id: bridge?.getSessionId() ?? STUB_SESSION_ID,
-      sessionReplay,
-      anonymousId: bridge?.getAnonymousId(),
-    }),
+    // Read from the bridge on each call rather than from `lastSeenSessionId`: the poll above only
+    // exists to spot transitions, and an event assembled between two polls must still carry the id
+    // the host holds right now.
+    findTrackedSession: (): RumSession | undefined => {
+      const sessionId = readHostSessionId()
+      if (sessionId === NO_HOST_SESSION) {
+        // The host owns the session and currently has none. There is nothing to attribute this
+        // page's data to, so it has no tracked session either — falling back to the placeholder
+        // would pile Session Replay segments onto a fake session shared across applications, and
+        // reusing the id the host had a moment ago would pile them onto a session that ended.
+        return
+      }
+      return {
+        id: sessionId ?? STUB_SESSION_ID,
+        sessionReplay,
+        anonymousId: bridge?.getAnonymousId(),
+      }
+    },
     expire: noop,
-    expireObservable: new Observable(),
+    expireObservable,
     setForcedReplay: noop,
+    stop: () => clearInterval(watchIntervalId),
   }
 }
 

--- a/packages/rum/src/boot/recorderApi.spec.ts
+++ b/packages/rum/src/boot/recorderApi.spec.ts
@@ -30,7 +30,12 @@ describe('makeRecorderApi', () => {
   function setupRecorderApi({
     sessionManager,
     startSessionReplayRecordingManually,
-  }: { sessionManager?: RumSessionManager; startSessionReplayRecordingManually?: boolean } = {}) {
+    sessionReplayDirectUpload,
+  }: {
+    sessionManager?: RumSessionManager
+    startSessionReplayRecordingManually?: boolean
+    sessionReplayDirectUpload?: boolean
+  } = {}) {
     mockWorker = new MockWorker()
     createDeflateWorkerSpy = jasmine.createSpy('createDeflateWorkerSpy').and.callFake(() => mockWorker)
     spyOn(display, 'error')
@@ -51,7 +56,10 @@ describe('makeRecorderApi', () => {
     rumInit = ({ worker } = {}) => {
       recorderApi.onRumStart(
         lifeCycle,
-        mockRumConfiguration({ startSessionReplayRecordingManually: startSessionReplayRecordingManually ?? false }),
+        mockRumConfiguration({
+          startSessionReplayRecordingManually: startSessionReplayRecordingManually ?? false,
+          sessionReplayDirectUpload: sessionReplayDirectUpload ?? false,
+        }),
         sessionManager ?? createRumSessionManagerMock().setId('1234'),
         mockViewHistory(),
         worker
@@ -258,6 +266,18 @@ describe('makeRecorderApi', () => {
 
         expect(loadRecorderSpy).not.toHaveBeenCalled()
         expect(startRecordingSpy).not.toHaveBeenCalled()
+      })
+
+      // FLASHCAT FORK - see `sessionReplayDirectUpload` in RumInitConfiguration.
+      it('should start recording when the bridge does not support records but sessionReplayDirectUpload is set', async () => {
+        mockEventBridge({ capabilities: [] })
+
+        setupRecorderApi({ startSessionReplayRecordingManually: true, sessionReplayDirectUpload: true })
+        rumInit()
+        recorderApi.start()
+        await collectAsyncCalls(startRecordingSpy, 1)
+
+        expect(startRecordingSpy).toHaveBeenCalled()
       })
     })
 

--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -31,7 +31,7 @@ export function makeRecorderApi(
   loadRecorder: () => Promise<StartRecording | undefined>,
   createDeflateWorkerImpl?: CreateDeflateWorker
 ): RecorderApi {
-  // FLASHCAT FORK (1/3) - see `sessionReplayDirectUpload` in RumInitConfiguration.
+  // FLASHCAT FORK (1/4) - see `sessionReplayDirectUpload` in RumInitConfiguration.
   // Upstream also disables the recorder here when an event bridge is present without the `records`
   // capability. That check now lives in `onRumStart` below, because it depends on a configuration
   // option that is not known yet when this function runs.
@@ -90,7 +90,7 @@ export function makeRecorderApi(
     viewHistory: ViewHistory,
     worker: DeflateWorker | undefined
   ) {
-    // FLASHCAT FORK (1/3) - see `sessionReplayDirectUpload` in RumInitConfiguration.
+    // FLASHCAT FORK (1/4) - see `sessionReplayDirectUpload` in RumInitConfiguration.
     // A host application declaring the `records` capability collects the records itself. When it
     // does not, upstream gives up on Session Replay entirely; `sessionReplayDirectUpload` opts out
     // of that and keeps the regular in-page recorder running.

--- a/packages/rum/src/boot/recorderApi.ts
+++ b/packages/rum/src/boot/recorderApi.ts
@@ -31,7 +31,11 @@ export function makeRecorderApi(
   loadRecorder: () => Promise<StartRecording | undefined>,
   createDeflateWorkerImpl?: CreateDeflateWorker
 ): RecorderApi {
-  if ((canUseEventBridge() && !bridgeSupports(BridgeCapability.RECORDS)) || !isBrowserSupported()) {
+  // FLASHCAT FORK (1/3) - see `sessionReplayDirectUpload` in RumInitConfiguration.
+  // Upstream also disables the recorder here when an event bridge is present without the `records`
+  // capability. That check now lives in `onRumStart` below, because it depends on a configuration
+  // option that is not known yet when this function runs.
+  if (!isBrowserSupported()) {
     return {
       start: noop,
       stop: noop,
@@ -86,6 +90,14 @@ export function makeRecorderApi(
     viewHistory: ViewHistory,
     worker: DeflateWorker | undefined
   ) {
+    // FLASHCAT FORK (1/3) - see `sessionReplayDirectUpload` in RumInitConfiguration.
+    // A host application declaring the `records` capability collects the records itself. When it
+    // does not, upstream gives up on Session Replay entirely; `sessionReplayDirectUpload` opts out
+    // of that and keeps the regular in-page recorder running.
+    if (canUseEventBridge() && !bridgeSupports(BridgeCapability.RECORDS) && !configuration.sessionReplayDirectUpload) {
+      return
+    }
+
     let cachedDeflateEncoder: DeflateEncoder | undefined
 
     function getOrCreateDeflateEncoder() {

--- a/packages/rum/src/boot/startRecording.spec.ts
+++ b/packages/rum/src/boot/startRecording.spec.ts
@@ -1,6 +1,6 @@
 import type { TimeStamp, HttpRequest } from '@flashcatcloud/browser-core'
 import { PageExitReason, DefaultPrivacyLevel, noop, DeflateEncoderStreamId } from '@flashcatcloud/browser-core'
-import type { ViewCreatedEvent } from '@flashcatcloud/browser-rum-core'
+import type { RumConfiguration, ViewCreatedEvent } from '@flashcatcloud/browser-rum-core'
 import { LifeCycle, LifeCycleEventType, startViewHistory } from '@flashcatcloud/browser-rum-core'
 import {
   collectAsyncCalls,
@@ -30,8 +30,11 @@ describe('startRecording', () => {
   let requestSendSpy: jasmine.Spy<HttpRequest['sendOnExit']>
   let stopRecording: () => void
 
-  function setupStartRecording() {
-    const configuration = mockRumConfiguration({ defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW })
+  function setupStartRecording(partialConfiguration: Partial<RumConfiguration> = {}) {
+    const configuration = mockRumConfiguration({
+      defaultPrivacyLevel: DefaultPrivacyLevel.ALLOW,
+      ...partialConfiguration,
+    })
     resetReplayStats()
     const worker = startDeflateWorker(configuration, 'Session Replay', noop)
 
@@ -235,6 +238,19 @@ describe('startRecording', () => {
       event: jasmine.objectContaining({ type: RecordType.Meta }),
       view: { id: 'view-id-2' },
     })
+  })
+
+  // FLASHCAT FORK - see `sessionReplayDirectUpload` in RumInitConfiguration.
+  it('should send segments itself when the bridge is present but sessionReplayDirectUpload is set', async () => {
+    const eventBridge = mockEventBridge()
+    const sendSpy = spyOn(eventBridge, 'send')
+    setupStartRecording({ sessionReplayDirectUpload: true })
+
+    flushSegment(lifeCycle)
+
+    const requests = await readSentRequests(1)
+    expect(requests[0].metadata.session).toEqual({ id: 'session-id' })
+    expect(sendSpy).not.toHaveBeenCalled()
   })
 
   function initialView(lifeCycle: LifeCycle) {

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -28,7 +28,7 @@ export function startRecording(
 
   let addRecord: (record: BrowserRecord) => void
 
-  // FLASHCAT FORK (2/3) - see `sessionReplayDirectUpload` in RumInitConfiguration.
+  // FLASHCAT FORK (2/4) - see `sessionReplayDirectUpload` in RumInitConfiguration.
   // Without the option, records are handed over to the host application through the bridge. With
   // it, they go through the regular segment collection and are uploaded from this page.
   if (!canUseEventBridge() || configuration.sessionReplayDirectUpload) {

--- a/packages/rum/src/boot/startRecording.ts
+++ b/packages/rum/src/boot/startRecording.ts
@@ -28,7 +28,10 @@ export function startRecording(
 
   let addRecord: (record: BrowserRecord) => void
 
-  if (!canUseEventBridge()) {
+  // FLASHCAT FORK (2/3) - see `sessionReplayDirectUpload` in RumInitConfiguration.
+  // Without the option, records are handed over to the host application through the bridge. With
+  // it, they go through the regular segment collection and are uploaded from this page.
+  if (!canUseEventBridge() || configuration.sessionReplayDirectUpload) {
     const segmentCollection = startSegmentCollection(
       lifeCycle,
       configuration,


### PR DESCRIPTION
## What

Adds a `sessionReplayDirectUpload` init option to `@flashcatcloud/browser-rum`, so that a page embedded in a host application keeps collecting Session Replay and uploads it itself, instead of handing it over to the host.

Draft: **do not merge, do not publish.**

**Baseline: this branch is cut from `publish` (`97bcf9b7`, v0.0.6), which is this fork's mainline — not `main`.** `main` is stuck 75 commits behind at the fork point; npm `@flashcatcloud/browser-core@0.0.6` matches `publish`. An earlier revision of this work was mistakenly based on `main` (PR #17, now closed).

## Why

When the SDK runs inside a host application that injects a `DatadogEventBridge` (an Electron renderer process, a mobile WebView), upstream assumes the host takes over Session Replay. If the host does not declare the `records` capability, the whole recorder API is replaced by a no-op shell and no replay is collected at all.

Our Electron SDK (`@flashcatcloud/electron-sdk`) injects the bridge from its preload script but returns an empty capability list, so customers who had working Session Replay lose it as soon as they adopt the Electron SDK.

The upstream design — the host receives raw records over `bridge.send('record', ...)` and does the segmentation, compression and multipart upload itself — is a large amount of work and has no Electron implementation upstream to this day. This change takes the other route: let the page stay on the path it already uses on the web.

The intake side needs no change. The payload, the endpoint builder (including `proxy`, which applies to the `replay` track exactly like to `rum`) and the authentication (`dd-api-key` = the same client token) are the ones a plain web page already uses. This was verified end to end on dev: segments uploaded from an application of type `electron`, both direct and through a `ddforward` proxy, return `202`, land in S3 and in `t_replay_segments`, and the read endpoint hands back a presigned URL.

## The four change points

They are the only behavioral changes, each marked `FLASHCAT FORK (n/4)` in the code so the fork delta stays easy to spot if an upstream patch ever has to be picked. Points 1-3 turn the recorder back on; point 4 is what makes the resulting uploads actually accepted, and was added after the first end-to-end round on Electron.

1. **`packages/rum/src/boot/recorderApi.ts`** — the recorder is no longer disabled up front when a bridge is present without the `records` capability. That check moved from `makeRecorderApi()` into `onRumStart()`, because it now depends on a configuration option, and the configuration does not exist yet when `makeRecorderApi()` runs at module evaluation. `makeRecorderApi()` keeps only the browser support check; the resulting behavior for a host that does not opt in is unchanged (the strategy stays the pre-start one, so `isRecording()` is `false`, `getReplayStats()` and `getSessionReplayLink()` are `undefined`, and no worker is ever started).
2. **`packages/rum/src/boot/startRecording.ts`** — records go to `startSegmentCollection` (segment + upload) instead of `startRecordBridge` (hand over to the host).
3. **`packages/rum-core/src/domain/rumSessionManager.ts`** — the stub session is marked `SAMPLED`, so view events carry `session.has_replay`. That flag is what the read side keys on to expose the replay; without it the segments would be uploaded but never reachable.
4. **`packages/rum-core/src/boot/preStartRum.ts`** — `overrideInitConfigurationForBridge()` no longer replaces `clientToken` with the literal `'empty'` and `applicationId` with a placeholder when the option is set. See below; without this every segment is rejected with 401.

Plus one correctness fix that falls out of point 3, in `packages/rum-core/src/domain/contexts/userContext.ts` — also below.

## Why point 4 is required, not cosmetic

`overrideInitConfigurationForBridge()` swaps the real credentials for placeholders:

```ts
applicationId: '00000000-aaaa-0000-aaaa-000000000000',
clientToken: 'empty',
```

That is sound upstream, because the premise is that a page hosting a bridge never sends a request of its own. **This PR breaks exactly that premise**: the page starts sending replay requests again, and it was sending them with the string `'empty'` as its credential.

The first end-to-end round pinned it down by comparison — same URL, same payload, only the key changed:

| credential | result |
|---|---|
| `dd-api-key=empty` | **401** |
| real client token | **400** (authenticated; the probe payload was just synthetic) |
| real token + real application id + a well formed segment | **202**, stored, with `acct_id`/`session_id` matching its session row |

So the join logic was fine all along and only the credential was blocking. The application id matters too, not just the token: `computeSegmentContext()` builds segment metadata from `configuration.applicationId`, and `t_replay_segments.application_id` is a NOT NULL column.

Keeping both is safe for everything else. RUM events under a bridge go through `bridge.send()` and never touch HTTP, so the credentials are irrelevant to them. And the renderer's `application.id` is overwritten by the Electron main process in `assembleRendererRumEvent` anyway, so restoring the real one introduces no inconsistency. `sessionSampleRate: 100` is left exactly as upstream has it.

## The `usr.id` fix

`userContext.ts` contains a Flashcat-only line (not upstream):

```ts
user.id = isEmptyObject(user) ? session.anonymousId : user.id
```

Giving the stub session an `anonymousId` in point 3 **activated** it — the first round measured every renderer process event carrying `usr.id = anonymous_id`, 6 of 6.

That is unwanted here. A host application's unique-user baseline already prefers the anonymous id (`COALESCE(usr_anonymous_id, usr_id)`), and that id is stable across logins, so the copy buys nothing — while importing the web's double-counting bug, where one device counts as two users before and after a login. `fc-sdk-electron` deliberately does not backfill on the main process side, and the renderer now matches.

**Web behavior is deliberately untouched**, since this file is shared by every web customer and that line is why web unique users are countable at all: the web baseline counts only `usr.id`, so without the backfill every logged-out visitor is missed. The skip is therefore conditional.

The condition is **`canUseEventBridge()`, not the new option**. The anonymous id becomes host-owned as soon as a bridge supplies it, whether or not direct upload is enabled, so gating on the option would leave the same double-counting in place for a host that provides `getAnonymousId()` without opting into replay. Bridge presence is what actually delimits "this id is ours" from "this id is the host's". It is evaluated once, since a bridge is injected before any page script runs.

Both sides are pinned by tests: the web backfill (which had no test before) and the bridge case where `usr.id` stays absent while `usr.anonymous_id` is set.

## Session id and anonymous id

This is the part the approach stands or falls on.

With a bridge present, the page uses `startRumSessionManagerStub()`, whose session id is the hardcoded placeholder `00000000-aaaa-0000-aaaa-000000000000`. That is fine upstream because the host overwrites `session.id` on every RUM event it forwards — which our Electron main process does. **But nobody overwrites the session id of a replay segment**, since the segment is uploaded by the page directly. Segments are joined to a session by `(account, session id)`, so a placeholder id means the replay is stored and never associated with a real session.

The stub therefore reads the identifiers the host actually owns, through two new **optional** methods on the bridge:

```ts
getSessionId?(): string
getAnonymousId?(): string
```

Both are feature-detected: a host built against an older SDK does not implement them, and the page falls back to the placeholder session id and to no anonymous id, rather than crashing. The session id is read on every `findTrackedSession()` call, because the host renews it over time.

`getAnonymousId()` also fixes a second problem: the stub session had no `anonymousId` field at all, so `usr.anonymous_id` was always empty in a host application and unique user counts were always zero.

The host side of the contract is implemented and verified in flashcatcloud/fc-sdk-electron#11.

## Configuration

```ts
flashcatRum.init({
  applicationId: '...',
  clientToken: '...',
  sessionReplayDirectUpload: true,
  sessionReplaySampleRate: 100, // required, see below
})
```

`sessionReplaySampleRate` **defaults to 0**, and this option does not change that. Enabling `sessionReplayDirectUpload` alone records nothing. The sample rate is applied to the stub session as well, so it has to be set explicitly. This is called out in the option's TSDoc.

The option has no effect outside a host application: without a bridge the page already records and uploads Session Replay.

## Tests

New specs cover each branch:

- `recorderApi.spec.ts` — the recorder starts when the bridge does not support records but the option is set (the existing "should not start recording" case is untouched and still passes).
- `startRecording.spec.ts` — with a bridge present and the option set, segments are sent over the SDK's own request and nothing goes through `bridge.send`.
- `rumSessionManager.spec.ts` — the session is `SAMPLED` with the option set, `OFF` when `sessionReplaySampleRate` is 0; the bridge-provided session id and anonymous id are used, the placeholder is used when the bridge does not implement the methods or returns an empty string, and the session id is re-read on each call.
- `preStartRum.spec.ts` — credentials are still replaced by placeholders by default, and kept when the option is set.
- `userContext.spec.ts` — the web backfill is pinned (it had no coverage before), and under a bridge `usr.id` is not backfilled while `usr.anonymous_id` is still set, with a customer-provided `usr.id` left untouched.

`mockEventBridge` gained optional `sessionId` / `anonymousId`; omitting them leaves the methods off the mock entirely, which is what emulates an older host.

No existing assertion was relaxed or removed. `configuration.spec.ts` was updated only to include the new key in the exhaustive `Required<RumInitConfiguration>` object (the option is not reported to telemetry).

## Checks

Green on this baseline, with no assertion relaxed or removed:

- `yarn test:unit` — 2669/2683 passing, 0 failures (baseline `publish` is 2656/2670, 0 failures; the delta is exactly the 13 new specs).
- `yarn typecheck` — 0 errors.
- `yarn lint` — 0 problems.
- `prettier --check` — clean on every touched file.

One local-setup note for reviewers: `packages/core` has to be built once (`tsc -p packages/core/tsconfig.cjs.json && tsc -p packages/core/tsconfig.esm.json`) before `yarn lint` / `yarn typecheck` resolve `@flashcatcloud/browser-core`. Without it you get ~246 spurious `import/no-unresolved` errors and 4 type errors in `developer-extension/`. This is a build-state artifact, not a code issue.


---

## Follow-up: no collection while the host has no session

Review caught a hole in the identifier handling above. A host that owns the session id answers `''` through the bridge while it has none — a session that timed out and has not been renewed. `getEventBridge().getSessionId()` folded that empty answer into `undefined`, the same value it returns for a host that does not implement the getter at all, and the stub then fell back to `STUB_SESSION_ID`.

RUM events survive that: the host overrides their session id, or drops them. **Session Replay segments do not** — this PR has the page upload them directly, so they reached the intake carrying a placeholder that is a single constant shared by every application built on the host. Records collected during the gap were both lost to the real session and mixed into a fake one shared across applications. The window is real: only a click counts as end-user activity in the Electron host, so scrolling or typing for 15 minutes expires the session while the recorder keeps running.

### What changed

- `eventBridge.ts` — `getSessionId()` now returns `undefined` **only** when the host does not implement the getter, and `''` when the host implements it and has no session. Any other falsy answer from an implementing host is normalised to `''`. The interface doc says so.
- `rumSessionManager.ts` — `findTrackedSession()` returns `undefined` for `''`. Nothing is cached: reusing the id the host held a moment ago would attribute records to a session that has ended, which is the same bug with a different id.
- `rumSessionManager.ts` — the stub now watches the host session and turns transitions into `SESSION_EXPIRED` / `SESSION_RENEWED`. It owns a `stop()`, which `startRum` registers as a cleanup task.

### Why this semantic

`findTrackedSession()` returning `undefined` is already this SDK's "no session" state, and the replay pipeline already knows what to do with it — `segmentCollection.ts` documents it verbatim: *"If the RUM session ends and no session id is available when creating a new segment, records will be ignored, until the session is renewed and a new session id is available."* So segment creation pauses and resumes on its own. No new concept, no new code path.

The watch exists because that alone is not enough. Without a `SESSION_EXPIRED`, the recorder keeps a segment open across the end of the host session (up to `SEGMENT_DURATION_LIMIT`), and after a renewal the next segment starts from an incremental record with no full snapshot — unplayable. Both are what `postStartStrategy` already handles for a regular session, so the stub feeds it the same two events.

Polling is not a new mechanism either: the bridge is pull-only, and the regular session manager learns of its own expiry the same way, polling its store every `STORAGE_POLL_DELAY` and turning the transitions into expire/renew notifications. The stub mirrors that, at the same interval, and only when the host actually answers for the session id — an older host never starts a timer.

### Tests

13 further specs, each verified by mutation (revert the behaviour, the spec fails):

| Mutation | Specs that fail |
|---|---|
| `getSessionId()` folds `''` back into `undefined` | 7 |
| `findTrackedSession()` falls back to the placeholder for `''` | 2 |
| the host-session watch is removed | 4 |

- `eventBridge.spec.ts` — the three answers are distinct, and a falsy answer from an implementing host normalises to `''`.
- `rumSessionManager.spec.ts` — no tracked session while the host reports none, never the placeholder, and a tracked session again on renewal; `SESSION_EXPIRED` on expiry, `SESSION_RENEWED` on renewal, both when the host swaps one session for another without reporting a gap, the manager already answering with the new session when it notifies, nothing notified while the host session is unchanged, no watch for a host that does not implement the getter, and no notifications after `stop()`.

The rest of the chain was already covered and is untouched: `computeSegmentContext` returns `undefined` when the session is not tracked, and `addRecord` ignores records with no context.

`yarn test:unit` — 2682/2696 passing, 0 failures (was 2669/2683; the delta is exactly the 13 new specs). `yarn typecheck`, `yarn lint`, `prettier --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
