### PR TITLE
fix(ci): make a pushed tag actually release again

### DIFF
--- a/.github/workflows/deploy-auto.yml
+++ b/.github/workflows/deploy-auto.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - 'v*' # 当推送带有 v 前缀的标签时触发
 
+# Unlike deploy-manual.yml, no job here asks for `fetch-tags`. This workflow is triggered *by* the
+# tag, so the tag is the ref being checked out and is already there — `check-release.js` finds it.
+# Asking for it on top makes checkout fetch the commit and the tag into the same `refs/tags/*`,
+# which git refuses: "Cannot fetch both <sha> and refs/tags/vX to refs/tags/vX". That failure took
+# down every tag-triggered release from v0.0.5 onwards.
+
 env:
   NODE_VERSION: '23.11.1'
   BUILD_MODE: release
@@ -16,8 +22,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -66,8 +70,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -103,8 +105,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -127,8 +127,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
 
       - name: Prepare notification
         run: |
@@ -157,8 +155,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
 
       - name: Prepare notification
         run: |

--- a/scripts/cli
+++ b/scripts/cli
@@ -63,6 +63,15 @@ cmd_build_json2type () {
 
 cmd_release () {
   [[ `git branch --show-current` != "main" ]] || fail 'please do not release from `main` branch'
+
+  # `lerna version` starts with `git remote update`, which fetches every remote and recurses into
+  # their submodules. Branches on the upstream fork reference `rum-events-format` commits its own
+  # remote does not serve, so that fetch fails and takes the release down before anything is
+  # tagged. Nothing here reads upstream, so keep it out of the update. Idempotent, and a no-op for
+  # anyone without that remote.
+  if git remote get-url upstream > /dev/null 2>&1; then
+    git config remote.upstream.skipDefaultUpdate true
+  fi
   # We should publish all packages regardless of if there are changes in each.
   # --force-publish will skip the `lerna changed` check for changed packages
   # https://github.com/lerna/lerna/tree/main/libs/commands/version#--force-publish


### PR DESCRIPTION
Releasing is supposed to be: push a tag, `deploy-auto.yml` takes it from there. That has not worked since v0.0.5 — **v0.0.5, v0.0.6 and v0.0.7 all shipped through the manual workflow instead**, and `yarn release` needed a hand-applied git config before it would even get as far as tagging.

| version | Automatic Deployment |
|---|---|
| v0.0.4-alpha.2 | success |
| v0.0.5 (twice) · v0.0.6 · v0.0.7 | **failure** |

## 1. Checkout could not check out the tag

```
fatal: Cannot fetch both <commit-sha> and refs/tags/v0.0.7 to refs/tags/v0.0.7
```

The workflow is triggered *by* the tag, so the tag is the ref being checked out and is already there. Asking for `fetch-tags` on top adds a second refspec pointing at the same `refs/tags/*`, and git refuses. Removed from all five checkouts here.

`deploy-manual.yml` keeps the flag, and needs it — it runs from a branch, where the tag is not the ref and `check-release.js` would otherwise not find it. That asymmetry is now written down in the workflow rather than left to be rediscovered.

Nothing else in this workflow needs tags: `check-release.js` resolves `v<version>`, which is the checked-out ref.

The failure was safe — it happened in checkout, so `deploy-prod` and `publish-npm` were skipped and nothing was ever published by mistake. But it produced a failed run and a `notify-failure` on every release, and left the real path undiscoverable.

## 2. `yarn release` died before tagging

`lerna version` starts with `git remote update`, which fetches **every** remote and recurses into their submodules. Branches on the upstream fork reference `rum-events-format` commits that its own remote does not serve:

```
fatal: remote error: upload-pack: not our ref d143baca...
Errors during submodule fetch: rum-events-format
error: could not fetch upstream
```

Nothing in a release reads upstream, so `cmd_release` now keeps it out of that update. Doing it there rather than in someone's `.git/config` means it holds on any clone — this was previously worked around by hand, on one machine.

Guarded on the remote existing, and idempotent.

## Verified

- `git remote update` fails, then passes once the guard has run — checked by clearing the config and re-running it.
- No empty `with:` blocks left behind in the workflow.

The checkout fix can only be proven by the next tag push, since that is the trigger. If it still fails, nothing publishes — the failure mode is unchanged and safe.